### PR TITLE
autogen: Fix #2, add configure option for iniparser

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,15 +61,19 @@ libbuxton_shared_la_SOURCES = \
 	src/shared/log.c \
 	src/shared/log.h \
 	src/include/bt-daemon-private.h \
-	src/shared/dictionary.c \
-	src/shared/dictionary.h \
-	src/shared/iniparser.c \
-	src/shared/iniparser.h \
 	src/shared/hashmap.c \
 	src/shared/hashmap.h \
 	src/shared/macro.h \
 	src/shared/util.h \
 	${NULL}
+
+if USE_LOCAL_INIPARSER
+libbuxton_shared_la_SOURCES += \
+	src/shared/dictionary.c \
+	src/shared/dictionary.h \
+	src/shared/iniparser.c \
+	src/shared/iniparser.h
+endif
 
 include_HEADERS += \
 	src/include/bt-daemon.h

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,15 @@ AC_ARG_WITH([user], AS_HELP_STRING([--with-user=USER],
 BUXTON_USERNAME="${username}"
 AC_SUBST(BUXTON_USERNAME)
 
+AC_ARG_WITH([local-iniparser],
+	AS_HELP_STRING([--with-local-iniparser[default=yes]],
+		[Use built-in iniparser for config parsing]),
+	[use_local_iniparser="true"],
+	[PKG_CHECK_MODULES([INIPARSER], [iniparser],
+		[use_local_iniparser="false"],
+		[use_local_iniparser="true"])])
+AM_CONDITIONAL([USE_LOCAL_INIPARSER], [test x$use_local_iniparser = x"true"])
+
 AC_CONFIG_FILES([
 data/buxton.service
 data/buxton.socket


### PR DESCRIPTION
Adds config option "--with-local-iniparser" [default=yes], which,
when set, will build using our built-in version of iniparser.

If explicitly unset, will perform a pkg-config check for iniparser,
which will fall back to our built-in version if not found.

Signed-off-by: Shane Bryan shane.bryan@intel.com
