### PR TITLE
Fix segfault on get_string

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -65,6 +65,7 @@ static void print_usage(Command *command)
 static bool set_value(BuxtonDataType type) {
 	char *layer, *key, *value;
 	BuxtonData set;
+	int ret, len = 0;
 
 	layer = arg_v[arg_n + 1];
 	key = arg_v[arg_n + 2];
@@ -73,7 +74,15 @@ static bool set_value(BuxtonDataType type) {
 	set.type = type;
 	switch (set.type) {
 		case STRING:
-			set.store.d_string = value;
+			len = strlen(value) + 1;
+			ret = snprintf(set.store.d_string,len,"%s",value);
+                        if (ret >= len) {
+				printf("Key value was truncated\n");
+				return false;
+			} else if (ret <= 0) {
+				buxton_log("set_value():snprintf(): %m\n");
+				return false;
+			}
 			break;
 		case BOOLEAN:
 			if (streq(value, "true"))
@@ -169,8 +178,6 @@ static bool get_value(BuxtonDataType type) {
 			break;
 	}
 end:
-	if (get.store.d_string)
-		free(get.store.d_string);
 
 	return ret;
 }

--- a/src/include/bt-daemon.h
+++ b/src/include/bt-daemon.h
@@ -42,8 +42,9 @@ typedef enum BuxtonDataType {
 	LONG,
 } BuxtonDataType;
 
+#define BUXTON_MAX_STRING_DATA_LEN 255
 typedef union BuxtonDataStore {
-	char *d_string;
+	char d_string[BUXTON_MAX_STRING_DATA_LEN];
 	bool d_boolean;
 	float d_float;
 	int d_int;

--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -90,10 +90,12 @@ char* get_layer_path(BuxtonLayer *layer)
 void buxton_data_copy(BuxtonData* original, BuxtonData *copy)
 {
 	BuxtonDataStore store;
+	int len = 0;
 
 	switch (original->type) {
 		case STRING:
-			store.d_string = strdup(original->store.d_string);
+			len = strlen(original->store.d_string)+1;
+			snprintf(store.d_string, len, "%s",original->store.d_string);
 			break;
 		case BOOLEAN:
 			store.d_boolean = original->store.d_boolean;


### PR DESCRIPTION
OK, So I've confirmed that changing d_string from char \* to char[] resolves the segfault issues we've been seeing, but not 100% sure that static char arrays is the "Right Thing" (tm) to do here... but figured I'd get input on this possible solution pushed so we can debate the merits or alternatives...
