### PR TITLE
Begin implementing set-value via wire protocol

### DIFF
--- a/src/shared/serialize.c
+++ b/src/shared/serialize.c
@@ -22,6 +22,7 @@
 #include "bt-daemon.h"
 #include "serialize.h"
 #include "util.h"
+#include "log.h"
 
 bool buxton_serialize(BuxtonData *source, uint8_t **target)
 {
@@ -273,10 +274,9 @@ end:
 	return ret;
 }
 
-int buxton_deserialize_message(uint8_t *data, BuxtonControlMessage *r_message,
+int buxton_deserialize_message(uint8_t *data, int size, BuxtonControlMessage *r_message,
 			       BuxtonData** list)
 {
-	int size = 0;
 	int offset = 0;
 	int ret = -1;
 	int min_length = BUXTON_CONTROL_LENGTH;
@@ -293,7 +293,6 @@ int buxton_deserialize_message(uint8_t *data, BuxtonControlMessage *r_message,
 	BuxtonData *k_list = NULL;
 	BuxtonData *c_data = NULL;
 
-	size = malloc_usable_size(data);
 	if (size < min_length)
 		goto end;
 

--- a/src/shared/serialize.h
+++ b/src/shared/serialize.h
@@ -81,11 +81,13 @@ bool buxton_serialize_message(uint8_t **dest, BuxtonControlMessage message,
 /**
  * Deserialize the given data into an array of BuxtonData structs
  * @param data The source data to be deserialized
+ * @param size Size of the data to be deserialized
  * @param message An empty pointer that will be set to the message type
  * @param list A pointer that will be filled out as an array of BuxtonData structs
  * @return the length of the array, or a negative value if deserialization failed
  */
-int buxton_deserialize_message(uint8_t *data, BuxtonControlMessage *message,
+int buxton_deserialize_message(uint8_t *data, int size,
+			       BuxtonControlMessage *message,
 			       BuxtonData **list);
 
 /*


### PR DESCRIPTION
I'm doing a lot out of tree right now because I need to disable smack on my local build-box, but this code does actually work.
Some output from my earlier tests:

```
[ikey@localhost buxton]$ sudo ./bt-daemon 
Added fd 4 to our poll list (accepting=1)
Added fd 3 to our poll list (accepting=0)
./bt-daemon: Started
New client fd 5 connected through fd 4
Added fd 5 to our poll list (accepting=0)
fgetxattr(): no security.SMACK64 label
fgetxattr(): label=""
New packet from UID 0, PID 24429
Recieved 3 parameters in set message
String value: base
String value: SomeRandomLengthedKey
String value: Some stupidly long value that really has no business being in a settings daemon anyway :)
Discarded 312 bytes on fd 0
Removing fd 5 from our list
Closed connection from fd 5
[ikey@localhost buxton]
```

This won't be testable _quite_ yet because we've not added errors + responses in, these require 2 way communication. I'll follow up with some commits in a separate branch or even ammend this one, but I'm putting this here mainly as reference, so that we can see how the protocol works (requires not closing socket in libbuxton)
