### PR TITLE
Switch to configurator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ bxt_timing
 *.gcda
 *.gcno
 /coverage
+test/databases/*.db
+test/test.conf
+check_configurator
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,6 +48,7 @@ uninstall-hook: systemdsystemunit-uninstall-hook
 
 distclean-local:
 	rm -f log-check-stderr-file
+	rm -f test/databases/*.db
 
 # set library version info
 LIBBUXTON_CURRENT=0
@@ -58,7 +59,8 @@ TESTS = \
 	check_buxton \
 	check_shared_lib \
 	check_daemon \
-	check_smack
+	check_smack \
+	check_configurator
 
 if COVERAGE
 coverage:
@@ -73,7 +75,8 @@ EXTRA_DIST = \
 	src/libbuxton/lbuxton.sym \
 	src/shared/constants.h \
 	test/test.load2 \
-	test/test.conf
+	test/test.conf \
+	test/test-configurator.conf
 
 dist_sysconf_DATA = \
 	data/buxton.conf
@@ -124,6 +127,8 @@ libbuxton_shared_la_SOURCES = \
 	src/shared/serialize.h \
 	src/shared/protocol.c \
 	src/shared/protocol.h \
+	src/shared/configurator.c \
+	src/shared/configurator.h \
 	${NULL}
 
 if USE_LOCAL_INIPARSER
@@ -208,7 +213,8 @@ check_PROGRAMS = \
 	check_shared_lib \
 	check_bt_daemon \
 	check_daemon \
-	check_smack
+	check_smack \
+	check_configurator
 
 check_buxton_SOURCES = \
 	src/shared/constants.c \
@@ -218,7 +224,9 @@ check_buxton_SOURCES = \
 check_buxton_CFLAGS = \
 	$(AM_CFLAGS) \
 	@CHECK_CFLAGS@ \
-	-DMAKE_CHECK
+	-DMAKE_CHECK \
+	-DABS_TOP_SRCDIR=\"$(abs_top_srcdir)\" \
+	-DABS_TOP_BUILDDIR=\"$(abs_top_builddir)\"
 check_buxton_LDADD = \
 	@CHECK_LIBS@ \
 	libbuxton.la \
@@ -233,7 +241,9 @@ check_shared_lib_CFLAGS = \
 	$(AM_CFLAGS) \
 	@CHECK_CFLAGS@ \
 	@INIPARSER_CFLAGS@ \
-	-DMAKE_CHECK
+	-DMAKE_CHECK \
+	-DABS_TOP_SRCDIR=\"$(abs_top_srcdir)\" \
+	-DABS_TOP_BUILDDIR=\"$(abs_top_builddir)\"
 check_shared_lib_LDADD = \
 	@CHECK_LIBS@ \
 	@INIPARSER_LIBS@ \
@@ -252,7 +262,9 @@ check_bt_daemon_CFLAGS = \
 	@CHECK_CFLAGS@ \
 	$(AM_CFLAGS) \
 	@INIPARSER_CFLAGS@ \
-	-DMAKE_CHECK
+	-DMAKE_CHECK \
+	-DABS_TOP_SRCDIR=\"$(abs_top_srcdir)\" \
+	-DABS_TOP_BUILDDIR=\"$(abs_top_builddir)\"
 check_bt_daemon_LDADD = \
 	@CHECK_LIBS@ \
 	$(SYSTEMD_LIBS) \
@@ -271,7 +283,9 @@ check_daemon_CFLAGS = \
 	$(AM_CFLAGS) \
 	@CHECK_CFLAGS@ \
 	@INIPARSER_CFLAGS@ \
-	-DMAKE_CHECK
+	-DMAKE_CHECK \
+	-DABS_TOP_SRCDIR=\"$(abs_top_srcdir)\" \
+	-DABS_TOP_BUILDDIR=\"$(abs_top_builddir)\"
 check_daemon_LDADD = \
 	@CHECK_LIBS@ \
 	@INIPARSER_LIBS@ \
@@ -288,12 +302,31 @@ check_smack_CFLAGS = \
 	$(AM_CFLAGS) \
 	@CHECK_CFLAGS@ \
 	@INIPARSER_CFLAGS@ \
-	-DMAKE_CHECK
+	-DMAKE_CHECK \
+	-DABS_TOP_SRCDIR=\"$(abs_top_srcdir)\" \
+	-DABS_TOP_BUILDDIR=\"$(abs_top_builddir)\"
 check_smack_LDADD = \
 	@CHECK_LIBS@ \
 	@INIPARSER_LIBS@ \
 	libbuxton.la \
 	libbuxton-security.la \
+	libbuxton-shared.la
+
+check_configurator_SOURCES = \
+	src/shared/constants.c \
+	src/shared/configurator.c \
+	src/shared/configurator.h \
+	test/check_configurator.c
+check_configurator_CFLAGS = \
+	$(AM_CFLAGS) \
+	@CHECK_CFLAGS@ \
+	@INIPARSER_CFLAGS@ \
+	-DMAKE_CHECK \
+	-DABS_TOP_SRCDIR=\"$(abs_top_srcdir)\" \
+	-DABS_TOP_BUILDDIR=\"$(abs_top_builddir)\"
+check_configurator_LDADD = \
+	@CHECK_LIBS@ \
+	@INIPARSER_LIBS@ \
 	libbuxton-shared.la
 
 check_DATA = \

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ LT_INIT([disable-static])
 AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_INSTALL
+AC_PROG_MKDIR_P
 
 # Checks for libraries.
 AC_CHECK_LIB([dl], [dlopen])
@@ -180,11 +181,13 @@ AS_IF([test "x$enable_demos" = "xyes"],
 	[])
 AM_CONDITIONAL([BUILD_DEMOS], [test x$enable_demos = x"yes"])
 
+AC_CONFIG_COMMANDS([mkdir], [$MKDIR_P test/databases])
 AC_CONFIG_FILES([
 data/buxton.service
 data/buxton.socket
 test/test-pass.ini
 test/test-fail.ini
+test/test.conf
 src/shared/constants.c
 ])
 AC_OUTPUT

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -37,6 +37,7 @@
 #include "log.h"
 #include "smack.h"
 #include "util.h"
+#include "configurator.h"
 
 #define SOCKET_TIMEOUT 5
 
@@ -114,7 +115,7 @@ int main(int argc, char *argv[])
 
 		memset(&sa, 0, sizeof(sa));
 		sa.un.sun_family = AF_UNIX;
-		strncpy(sa.un.sun_path, BUXTON_SOCKET, sizeof(sa.un.sun_path) - 1);
+		strncpy(sa.un.sun_path, buxton_socket(), sizeof(sa.un.sun_path) - 1);
 		sa.un.sun_path[sizeof(sa.un.sun_path)-1] = 0;
 
 		ret = unlink(sa.un.sun_path);
@@ -140,7 +141,7 @@ int main(int argc, char *argv[])
 			if (sd_is_fifo(fd, NULL)) {
 				add_pollfd(&self, fd, POLLIN, false);
 				buxton_debug("Added fd %d type FIFO\n", fd);
-			} else if (sd_is_socket_unix(fd, SOCK_STREAM, -1, BUXTON_SOCKET, 0)) {
+			} else if (sd_is_socket_unix(fd, SOCK_STREAM, -1, buxton_socket(), 0)) {
 				add_pollfd(&self, fd, POLLIN | POLLPRI, true);
 				buxton_debug("Added fd %d type UNIX\n", fd);
 			} else if (sd_is_socket(fd, AF_UNSPEC, 0, -1)) {
@@ -260,7 +261,7 @@ int main(int argc, char *argv[])
 	buxton_log("%s: Closing all connections\n", argv[0]);
 
 	if (manual_start)
-		unlink(BUXTON_SOCKET);
+		unlink(buxton_socket());
 	for (int i = 0; i < self.nfds; i++) {
 		close(self.pollfds[i].fd);
 	}

--- a/src/libbuxton/lbuxton.c
+++ b/src/libbuxton/lbuxton.c
@@ -34,6 +34,7 @@
 #include "log.h"
 #include "hashmap.h"
 #include "protocol.h"
+#include "configurator.h"
 
 bool buxton_client_open(BuxtonClient *client)
 {
@@ -48,7 +49,7 @@ bool buxton_client_open(BuxtonClient *client)
 	}
 
 	remote.sun_family = AF_UNIX;
-	strncpy(remote.sun_path, BUXTON_SOCKET, sizeof(remote.sun_path));
+	strncpy(remote.sun_path, buxton_socket(), sizeof(remote.sun_path));
 	r = connect(bx_socket, (struct sockaddr *)&remote, sizeof(remote));
 	client->fd = bx_socket;
 	if ( r == -1) {

--- a/src/shared/backend.c
+++ b/src/shared/backend.c
@@ -20,8 +20,8 @@
 #endif
 
 #include <dlfcn.h>
-#include <iniparser.h>
 
+#include "configurator.h"
 #include "backend.h"
 #include "bt-daemon.h"
 #include "hashmap.h"
@@ -35,13 +35,16 @@
 static Hashmap *_directPermitted = NULL;
 
 /**
- * Parse a given layer using the buxton configuration file
- * @param ini the configuration dictionary
- * @param name the layer to query
- * @param out The new BuxtonLayer to store
- * @return a boolean value, indicating success of the operation
+ * Create a BuxtonLayer out of a ConfigLayer
+ *
+ * Validates the data from the config file and creates BuxtonLayer.
+ *
+ * @param conf_layer the ConfigLayer to validate
+ *
+ * @return a new BuxtonLayer.  Callers are responsible for managing
+ * this memory
  */
-bool parse_layer(dictionary *ini, char *name, BuxtonLayer *out);
+static BuxtonLayer* buxton_layer_new(ConfigLayer *conf_layer);
 
 bool buxton_direct_open(BuxtonControl *control)
 {
@@ -254,128 +257,75 @@ bool buxton_init_layers(BuxtonConfig *config)
 {
 	Hashmap *layers = NULL;
 	bool ret = false;
-	dictionary *ini;
-	const char *path = DEFAULT_CONFIGURATION_FILE;
 	int nlayers = 0;
+	ConfigLayer *config_layers = NULL;
 
-	ini = iniparser_load(path);
-	if (ini == NULL) {
-		buxton_log("Failed to load buxton conf file: %s\n", path);
-		goto finish;
-	}
-
-	nlayers = iniparser_getnsec(ini);
-	if (nlayers <= 0) {
-		buxton_log("No layers defined in buxton conf file: %s\n", path);
-		goto end;
-	}
-
+	nlayers = buxton_get_layers(&config_layers);
 	layers = hashmap_new(string_hash_func, string_compare_func);
 	if (!layers)
 		goto end;
 
 	for (int n = 0; n < nlayers; n++) {
 		BuxtonLayer *layer;
-		char *section_name;
 
-		layer = malloc0(sizeof(BuxtonLayer));
+		layer = buxton_layer_new(&(config_layers[n]));
 		if (!layer)
 			continue;
 
-		section_name = iniparser_getsecname(ini, n);
-		if (!section_name) {
-			buxton_log("Failed to find section number: %d\n", n);
-			continue;
-		}
-
-		if (!parse_layer(ini, section_name, layer)) {
-			free(layer);
-			buxton_log("Failed to load layer: %s\n", section_name);
-			continue;
-		}
 		hashmap_put(layers, layer->name.value, layer);
 	}
 	ret = true;
 	config->layers = layers;
 
-end:
-	iniparser_freedict(ini);
-finish:
+ end:
+	free(config_layers);
 	return ret;
 }
 
-bool parse_layer(dictionary *ini, char *name, BuxtonLayer *out)
+static BuxtonLayer* buxton_layer_new(ConfigLayer *conf_layer)
 {
-	int r;
-	_cleanup_free_ char *k_desc = NULL;
-	_cleanup_free_ char *k_backend = NULL;
-	_cleanup_free_ char *k_type = NULL;
-	_cleanup_free_ char *k_priority = NULL;
-	char *_desc = NULL;
-	char *_backend = NULL;
-	char *_type = NULL;
-	int _priority;
+	BuxtonLayer *out;
 
-	assert(ini);
-	assert(name);
-	assert(out);
+	assert(conf_layer);
+	out= malloc0(sizeof(BuxtonLayer));
+	if (!out)
+		abort();
 
-	r = asprintf(&k_desc, "%s:description", name);
-	if (r == -1)
-		return false;
-
-	r = asprintf(&k_backend, "%s:backend", name);
-	if (r == -1)
-		return false;
-
-	r = asprintf(&k_type, "%s:type", name);
-	if (r == -1)
-		return false;
-
-	r = asprintf(&k_priority, "%s:priority", name);
-	if (r == -1)
-		return false;
-
-	_type = iniparser_getstring(ini, k_type, NULL);
-	_backend = iniparser_getstring(ini, k_backend, NULL);
-	_priority = iniparser_getint(ini, k_priority, -1);
-	_desc = iniparser_getstring(ini, k_desc, NULL);
-
-	if (!_type || !name || !_backend || _priority < 0)
-		return false;
-
-	out->name.value = strdup(name);
+	if (conf_layer->priority < 0)
+		goto fail;
+	out->name.value = strdup(conf_layer->name);
 	if (!out->name.value)
 		goto fail;
-	out->name.length = (uint32_t)strlen(name);
+	out->name.length = (uint32_t)strlen(conf_layer->name);
 
-	if (strcmp(_type, "System") == 0)
+	if (strcmp(conf_layer->type, "System") == 0) {
 		out->type = LAYER_SYSTEM;
-	else if (strcmp(_type, "User") == 0)
+	} else if (strcmp(conf_layer->type, "User") == 0) {
 		out->type = LAYER_USER;
-	else {
-		buxton_log("Layer %s has unknown type: %s\n", name, _type);
+	} else {
+		buxton_log("Layer %s has unknown type: %s\n", conf_layer->name, conf_layer->type);
 		goto fail;
 	}
 
-	if (strcmp(_backend, "gdbm") == 0)
+	if (strcmp(conf_layer->backend, "gdbm") == 0) {
 		out->backend = BACKEND_GDBM;
-	else if(strcmp(_backend, "memory") == 0)
+	} else if(strcmp(conf_layer->backend, "memory") == 0) {
 		out->backend = BACKEND_MEMORY;
-	else
+	} else {
+		buxton_log("Layer %s has unknown database: %s\n", conf_layer->name, conf_layer->backend);
 		goto fail;
+	}
 
-	if (_desc != NULL)
-		out->description = strdup(_desc);
+	if (conf_layer->description != NULL)
+		out->description = strdup(conf_layer->description);
 
-	out->priority = _priority;
-	return true;
-
-
-fail:
+	out->priority = conf_layer->priority;
+	return out;
+ fail:
 	free(out->name.value);
 	free(out->description);
-	return false;
+	free(out);
+	return NULL;
 }
 
 static bool init_backend(BuxtonConfig *config,
@@ -413,7 +363,7 @@ static bool init_backend(BuxtonConfig *config,
 	if (!backend_tmp)
 		return false;
 
-	r = asprintf(&path, "%s/%s.so", MODULE_DIRECTORY, name);
+	r = asprintf(&path, "%s/%s.so", buxton_module_dir(), name);
 	if (r == -1)
 		return false;
 

--- a/src/shared/configurator.c
+++ b/src/shared/configurator.c
@@ -1,0 +1,309 @@
+/*
+ * This file is part of buxton.
+ *
+ * Copyright (C) 2013 Intel Corporation
+ *
+ * buxton is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include "config.h"
+#endif
+
+#include "configurator.h"
+#include "log.h"
+#include "constants.h"
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+#include <linux/limits.h>
+#include <iniparser.h>
+
+/**
+ * Section name in ini file for our configuration
+ */
+#define CONFIG_SECTION "Configuration"
+
+/**
+ * @internal
+ * internal state of configurator
+ */
+static struct _conf {
+	bool initialized;	/**< track if it's been init'd */
+	char* keys[CONFIG_MAX];	/**< bag of values */
+	dictionary* ini;	/**< ini parser dictionary */
+} conf = {
+	.initialized = false,
+	.keys = {0},
+	.ini = NULL
+};
+
+/**
+ * @internal
+ * config keys as in environment
+ * @fixme name sucks
+ */
+static const char *KS[CONFIG_MAX] = {
+        NULL,
+	"BUXTON_CONF_FILE",
+	"BUXTON_MODULE_DIR",
+	"BUXTON_DB_PATH",
+	"BUXTON_SMACK_LOAD_FILE",
+	"BUXTON_BUXTON_SOCKET"
+};
+
+/**
+ * @internal
+ * keys as they are used in config file
+ */
+static const char *config_keys[CONFIG_MAX] = {
+	NULL,
+	NULL,			/**< conf file entry in config file is meaningless */
+	"ModuleDirectory",
+	"DatabasePath",
+	"SmackLoadFile",
+	"SocketPath"
+};
+
+static const char *COMPILE_DEFAULT[CONFIG_MAX] = {
+	NULL,
+	_DEFAULT_CONFIGURATION_FILE,
+	_MODULE_DIRECTORY,
+	_DB_PATH,
+	_SMACK_LOAD_FILE,
+	_BUXTON_SOCKET
+};
+
+/**
+ * @internal
+ * wrap strdup and die if malloc fails
+ *
+ * @note This may seem lame and stupid at first glance.  The former is
+ * right the latter is not.  This function may abort()
+ *
+ * @return pointer to dup'd string
+ */
+__attribute__ ((pure))
+static inline char *_strdup(const char* string)
+{
+	char* s;
+
+	s = strdup(string);
+	if (s == NULL)
+		abort();
+	return s;
+}
+
+/**
+ * @internal
+ * grab a string from the ini file
+ *
+ * @param section the section of the ini file
+ * @param name the name of the key
+ *
+ * @note This function may abort()
+ *
+ * @return The value as a string.  The the string is internal to
+ * libini, and if at this stage of the game it is null, just die.
+ * Somethign is really wrong and even if we could recover, the system
+ * is not working correctly.
+ */
+static char *get_ini_string(char *section, char *name)
+{
+	char buf[PATH_MAX];
+	char *s;
+
+	assert(conf.ini);
+	snprintf(buf, sizeof(buf), "%s:%s", section, name);
+	s = iniparser_getstring(conf.ini, buf, NULL);
+	if (s == NULL)
+		abort();
+	return s;
+}
+
+/**
+ * analagous method to get_ini_string()
+ *
+ * @param section the section of the ini file
+ * @param name the name of the key
+ *
+ * @note inlined b/c only used once and why not.
+ *
+ * @return the value
+ */
+static inline int get_ini_int(char *section, char *name)
+{
+	char buf[PATH_MAX];
+
+	assert(conf.ini);
+	snprintf(buf, sizeof(buf), "%s:%s", section, name);
+	return iniparser_getint(conf.ini, buf, -1);
+}
+
+/**
+ * @internal
+ * Initialize conf
+ *
+ */
+static void initialize(void)
+{
+	if (conf.initialized)
+		return;
+
+	for (int i= CONFIG_MIN+1; i < CONFIG_MAX; i++) {
+		char *envkey;
+
+		/* hasn't been set through command line */
+		if (conf.keys[i] == NULL) {
+			/* second priority is env */
+			envkey = secure_getenv(KS[i]);
+			if (envkey) {
+				conf.keys[i] = _strdup(envkey);
+			}
+		}
+
+		/* third priority is conf file */
+		if (conf.keys[i] == NULL && conf.ini) {
+			/* for once config file is loaded */
+			char key[PATH_MAX+strlen(CONFIG_SECTION)+1+1]; /* one for null and one for : */
+			char *value;
+
+			snprintf(key, sizeof(key), "%s:%s", CONFIG_SECTION, config_keys[i]);
+			value = iniparser_getstring(conf.ini, key, NULL);
+			if (value != NULL)
+				conf.keys[i] = _strdup(value);
+		}
+
+		if (conf.keys[i] == NULL) {
+			/* last priority is compile time defaults */
+			conf.keys[i] = _strdup(COMPILE_DEFAULT[i]);
+		}
+
+		/* if config file is not loaded, load */
+		if (i == CONFIG_CONF_FILE) {
+			char *path = conf.keys[CONFIG_CONF_FILE];
+
+			assert(conf.ini == NULL);
+			conf.ini = iniparser_load(path);
+			if (conf.ini == NULL) {
+				buxton_log("Failed to load buxton conf file: %s\n", path);
+			}
+		}
+	}
+}
+
+/**
+ * @internal
+ * use a destructor to free everything rather than yucky at_exit
+ * nonsense
+ *
+ * @return
+ */
+__attribute__ ((destructor)) static void free_conf(void)
+{
+	if (!conf.initialized)
+		return;
+	for (int i= CONFIG_MIN+1; i < CONFIG_MAX; i++) {
+		free(conf.keys[i]);
+	}
+	iniparser_freedict(conf.ini);
+}
+
+void buxton_add_cmd_line(ConfigKey confkey, char* data)
+{
+	if (confkey >= CONFIG_MAX || confkey <= CONFIG_MIN) {
+		buxton_log("invalid confkey");
+		return;
+	}
+	if (!data) {
+		buxton_log("invalid data");
+		return;
+	}
+
+	conf.keys[confkey] = _strdup(data);
+}
+
+char* buxton_module_dir(void)
+{
+	initialize();
+	return conf.keys[CONFIG_MODULE_DIR];
+}
+
+char* buxton_conf_file(void)
+{
+	initialize();
+	return conf.keys[CONFIG_CONF_FILE];
+}
+
+char* buxton_db_path(void)
+{
+	initialize();
+	return conf.keys[CONFIG_DB_PATH];
+}
+
+char* buxton_smack_load_file(void)
+{
+	initialize();
+	return conf.keys[CONFIG_SMACK_LOAD_FILE];
+}
+
+char* buxton_socket(void)
+{
+	initialize();
+	return conf.keys[CONFIG_BUXTON_SOCKET];
+}
+
+int buxton_get_layers(ConfigLayer **layers)
+{
+	ConfigLayer *_layers;
+	int n;
+	int j = 0;
+
+	assert(layers);
+	initialize();
+	if (conf.ini == NULL) {
+		buxton_log("config file not loaded when calling buxton_get_layers()");
+		abort();
+	}
+	n = iniparser_getnsec(conf.ini);
+	_layers = (ConfigLayer*)calloc((size_t)n, sizeof(ConfigLayer));
+	if (_layers == NULL)
+	        abort();
+	for (int i= 0; i < n; i++) {
+		char *section_name;
+
+		section_name = iniparser_getsecname(conf.ini, i);
+		if (!section_name)
+			abort();
+		if (!strcasecmp(section_name, CONFIG_SECTION))
+			continue;
+		_layers[j].name = section_name;
+		_layers[j].description = get_ini_string(section_name, "Description");
+		_layers[j].backend = get_ini_string(section_name, "Backend");
+		_layers[j].type = get_ini_string(section_name, "Type");
+		_layers[j].priority = get_ini_int(section_name, "Priority");
+		j++;
+	}
+	*layers = _layers;
+	return j;
+}
+
+
+
+/*
+ * Editor modelines  -  http://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: t
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 noexpandtab:
+ * :indentSize=8:tabSize=8:noTabs=false:
+ */

--- a/src/shared/configurator.h
+++ b/src/shared/configurator.h
@@ -1,0 +1,125 @@
+/*
+ * This file is part of buxton.
+ *
+ * Copyright (C) 2013 Intel Corporation
+ *
+ * buxton is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+/**
+ * \file configurator.h Internal header
+ * This file is used internally by buxton to provide functionality
+ * used to handle the configuration
+ */
+#pragma once
+
+#ifdef HAVE_CONFIG_H
+    #include "config.h"
+#endif
+
+typedef enum ConfigKey {
+        CONFIG_MIN = 0,
+	CONFIG_CONF_FILE,
+	CONFIG_MODULE_DIR,
+	CONFIG_DB_PATH,
+	CONFIG_SMACK_LOAD_FILE,
+	CONFIG_BUXTON_SOCKET,
+	CONFIG_MAX
+	} ConfigKey;
+
+/**
+ * Slightly duplicative of BuxtonLayer, but defined here instead of
+ * there.  This will probably be deprecated for BuxtonLayer once
+ * things are integrated.
+ */
+typedef struct ConfigLayer {
+	char *name;
+	char *type;
+	char *backend;
+	char *description;
+	int priority;
+} ConfigLayer;
+
+/**
+ * @internal
+ * @brief Add command line data
+ *
+ * @note This API is draft
+ */
+void buxton_add_cmd_line(ConfigKey confkey, char* data);
+
+/**
+ * @internal
+ * @brief Get the directory of plugin modules
+ *
+ * @return the path to the plugin module.  Do not free this pointer.
+ * It belongs to configurator.
+ */
+char *buxton_module_dir(void);
+
+/**
+ * @internal
+ * @brief Get the path of the config file
+ *
+ * @return the path of the config file.  Do not free this pointer.
+ * It belongs to configurator.
+ */
+char *buxton_conf_file(void);
+
+/**
+ * @internal
+ * @brief Get the path of the buxton database
+ *
+ *
+ * @return the path of the database file.  Do not free this pointer.
+ * It belongs to configurator.
+ */
+char *buxton_db_path(void);
+
+/**
+ * @internal
+ * @brief Get the path of the smack load file.
+ *
+ *
+ * @return the path of the smack load file.  Do not free this pointer.
+ * It belongs to configurator.
+ */
+char *buxton_smack_load_file(void);
+
+/**
+ * @internal
+ * @brief Get the path of the buxton socket.
+ *
+ *
+ * @return the path of the buxton socket.  Do not free this pointer.
+ * It belongs to configurator.
+ */
+char *buxton_socket(void);
+
+/**
+ * @internal
+ * @brief Get an array of ConfigLayers from the conf file
+ *
+ * @param layers pointer to a pointer where the array of ConfigLayers
+ * will be stored.  Callers should free this pointer with free when
+ * they are done with it.
+ *
+ * @return an integer that indicates the number of layers.
+ */
+int buxton_get_layers(ConfigLayer **layers);
+
+/*
+ * Editor modelines  -  http://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: t
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 noexpandtab:
+ * :indentSize=8:tabSize=8:noTabs=false:
+ */

--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
+#include "configurator.h"
 #include "hashmap.h"
 #include "log.h"
 #include "util.h"
@@ -66,14 +67,14 @@ char* get_layer_path(BuxtonLayer *layer)
 
 	switch (layer->type) {
 		case LAYER_SYSTEM:
-			r = asprintf(&path, "%s/%s.db", DB_PATH, layer->name.value);
+			r = asprintf(&path, "%s/%s.db", buxton_db_path(), layer->name.value);
 			if (r == -1)
 				return NULL;
 			break;
 		case LAYER_USER:
 			/* uid must already be set in layer before calling */
 			sprintf(uid, "%d", (int)layer->uid);
-			r = asprintf(&path, "%s/%s-%s.db", DB_PATH, layer->name.value, uid);
+			r = asprintf(&path, "%s/%s-%s.db", buxton_db_path(), layer->name.value, uid);
 			if (r == -1)
 				return NULL;
 			break;

--- a/test/check_buxton.c
+++ b/test/check_buxton.c
@@ -486,6 +486,7 @@ int main(void)
 	Suite *s;
 	SRunner *sr;
 
+	putenv("BUXTON_CONF_FILE=" ABS_TOP_BUILDDIR "/test/test.conf");
 	s = buxton_suite();
 	sr = srunner_create(s);
 	srunner_run_all(sr, CK_VERBOSE);

--- a/test/check_configurator.c
+++ b/test/check_configurator.c
@@ -1,0 +1,344 @@
+/*
+ * This file is part of buxton.
+ *
+ * Copyright (C) 2013 Intel Corporation
+ *
+ * buxton is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include "config.h"
+#endif
+
+#include <check.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <linux/limits.h>
+#include <stdbool.h>
+#include <iniparser.h>
+#include "configurator.h"
+#include "constants.h"
+
+static void fail_strne(char *value, char *correct_value, bool casecmp)
+{
+	char buf[PATH_MAX];
+	int ret;
+
+	snprintf(buf, sizeof(buf), "%s was not %s", value, correct_value);
+	if (casecmp)
+		ret = strcasecmp(value, correct_value);
+	 else
+		ret = strcmp(value, correct_value);
+	fail_unless(ret == 0, buf);
+}
+
+static void fail_ne(int a, int b)
+{
+	fail_unless(a == b, "%d is not %d", a, b);
+}
+
+static void default_test(char *value, char* correct_value, char *symbolname)
+{
+	char buf[PATH_MAX];
+
+	snprintf(buf, sizeof(buf), "%s returned null!", symbolname);
+	fail_if(value == NULL, buf);
+
+	snprintf(buf, sizeof(buf), "%s was not %s", value, correct_value);
+	fail_strne(value, correct_value, true);
+
+	free(value);
+}
+
+START_TEST(configurator_default_module_dir)
+{
+	default_test(buxton_module_dir(), (char*)_MODULE_DIRECTORY, "buxton_module_dir()");
+}
+END_TEST
+
+START_TEST(configurator_default_conf_file)
+{
+	default_test(buxton_conf_file(), (char*)_DEFAULT_CONFIGURATION_FILE, "buxton_conf_file()");
+}
+END_TEST
+
+START_TEST(configurator_default_db_path)
+{
+	default_test(buxton_db_path(), (char*)_DB_PATH, "buxton_db_path()");
+}
+END_TEST
+
+START_TEST(configurator_default_smack_load_file)
+{
+	 default_test(buxton_smack_load_file(), (char*)_SMACK_LOAD_FILE, "buxton_smack_load_file()");
+}
+END_TEST
+
+START_TEST(configurator_default_buxton_socket)
+{
+	default_test(buxton_socket(), (char*)_BUXTON_SOCKET, "buxton_socket()");
+}
+END_TEST
+
+
+START_TEST(configurator_env_conf_file)
+{
+	putenv("BUXTON_CONF_FILE=/nonexistant/buxton.conf");
+	default_test(buxton_conf_file(), "/nonexistant/buxton.conf", "buxton_conf_file()");
+}
+END_TEST
+
+START_TEST(configurator_env_module_dir)
+{
+	putenv("BUXTON_MODULE_DIR=/nonexistant/buxton/plugins");
+	default_test(buxton_module_dir(), "/nonexistant/buxton/plugins", "buxton_module_dir()");
+}
+END_TEST
+
+START_TEST(configurator_env_db_path)
+{
+	putenv("BUXTON_DB_PATH=/nonexistant/buxton.db");
+	default_test(buxton_db_path(), "/nonexistant/buxton.db", "buxton_db_path()");
+}
+END_TEST
+
+START_TEST(configurator_env_smack_load_file)
+{
+	putenv("BUXTON_SMACK_LOAD_FILE=/nonexistant/smack_load_file");
+	default_test(buxton_smack_load_file(), "/nonexistant/smack_load_file", "buxton_smack_load_file()");
+}
+END_TEST
+
+START_TEST(configurator_env_buxton_socket)
+{
+	putenv("BUXTON_BUXTON_SOCKET=/nonexistant/buxton_socket");
+	default_test(buxton_socket(), "/nonexistant/buxton_socket", "buxton_socket()");
+}
+END_TEST
+
+
+START_TEST(configurator_cmd_conf_file)
+{
+	char *correct = "herpyderpy";
+
+	buxton_add_cmd_line(CONFIG_CONF_FILE, correct);
+	putenv("BUXTON_CONF_FILE=/nonexistant/buxton.conf");
+	default_test(buxton_conf_file(), correct, "buxton_conf_file()");
+}
+END_TEST
+
+START_TEST(configurator_cmd_module_dir)
+{
+	char *correct = "herpyderpy";
+
+	buxton_add_cmd_line(CONFIG_MODULE_DIR, correct);
+	putenv("BUXTON_MODULE_DIR=/nonexistant/buxton/plugins");
+	default_test(buxton_module_dir(), correct, "buxton_module_dir()");
+}
+END_TEST
+
+START_TEST(configurator_cmd_db_path)
+{
+	char *correct = "herpyderpy";
+
+	buxton_add_cmd_line(CONFIG_DB_PATH, correct);
+	putenv("BUXTON_DB_PATH=/nonexistant/buxton.db");
+	default_test(buxton_db_path(), correct, "buxton_db_path()");
+}
+END_TEST
+
+START_TEST(configurator_cmd_smack_load_file)
+{
+	char *correct = "herpyderpy";
+
+	buxton_add_cmd_line(CONFIG_SMACK_LOAD_FILE, correct);
+	putenv("BUXTON_SMACK_LOAD_FILE=/nonexistant/smack_load_file");
+	default_test(buxton_smack_load_file(), correct, "buxton_smack_load_file()");
+}
+END_TEST
+
+START_TEST(configurator_cmd_buxton_socket)
+{
+	char *correct = "herpyderpy";
+
+	buxton_add_cmd_line(CONFIG_BUXTON_SOCKET, correct);
+	putenv("BUXTON_BUXTON_SOCKET=/nonexistant/buxton_socket");
+	default_test(buxton_socket(), correct, "buxton_socket()");
+}
+END_TEST
+
+
+START_TEST(configurator_conf_db_path)
+{
+	char *correct = "/you/are/so/suck";
+
+	putenv("BUXTON_CONF_FILE=" ABS_TOP_SRCDIR "/test/test-configurator.conf");
+	default_test(buxton_db_path(), correct, "buxton_db_path()");
+}
+END_TEST
+
+START_TEST(configurator_conf_smack_load_file)
+{
+	char *correct = "/smack/smack/smack";
+
+	putenv("BUXTON_CONF_FILE=" ABS_TOP_SRCDIR "/test/test-configurator.conf");
+	default_test(buxton_smack_load_file(), correct, "smack_load_file()");
+}
+END_TEST
+
+START_TEST(configurator_conf_buxton_socket)
+{
+	char *correct = "/hurp/durp/durp";
+
+	putenv("BUXTON_CONF_FILE=" ABS_TOP_SRCDIR "/test/test-configurator.conf");
+	default_test(buxton_socket(), correct, "buxton_socket()");
+}
+END_TEST
+
+START_TEST(configurator_conf_module_dir)
+{
+	char *correct = "/shut/your/mouth";
+
+	putenv("BUXTON_CONF_FILE=" ABS_TOP_SRCDIR "/test/test-configurator.conf");
+	default_test(buxton_module_dir(), correct, "buxton_module_dir()");
+}
+END_TEST
+
+START_TEST(configurator_get_layers)
+{
+	ConfigLayer *layers = NULL;
+	int numlayers;
+
+	putenv("BUXTON_CONF_FILE=" ABS_TOP_SRCDIR "/test/test-configurator.conf");
+	numlayers = buxton_get_layers(&layers);
+	fail_if(layers == NULL, "buxton_get_layers returned NULL");
+	fail_if(numlayers != 7, "num layers is %d instead of %d", numlayers, 7);
+
+	fail_strne(layers[0].name, "base", false);
+	fail_strne(layers[0].type, "System", false);
+	fail_strne(layers[0].backend, "gdbm", false);
+	fail_strne(layers[0].description, "Operating System configuration layer", false);
+	fail_ne(layers[0].priority, 0);
+
+	fail_strne(layers[1].name, "isp", false);
+	fail_strne(layers[1].type, "System", false);
+	fail_strne(layers[1].backend, "gdbm", false);
+	fail_strne(layers[1].description, "ISP specific settings", false);
+	fail_ne(layers[1].priority, 1);
+
+	/* ... */
+
+	fail_strne(layers[6].name, "test-gdbm-user", false);
+	fail_strne(layers[6].type, "User", false);
+	fail_strne(layers[6].backend, "gdbm", false);
+	fail_strne(layers[6].description, "GDBM test db for user", false);
+	fail_ne(layers[6].priority, 6000);
+
+
+
+}
+END_TEST
+
+START_TEST(ini_parse_check)
+{
+	char ini_good[] = "test/test-pass.ini";
+	char ini_bad[] = "test/test-fail.ini";
+	dictionary *ini = NULL;
+
+	ini = iniparser_load(ini_good);
+	fail_if(ini == NULL,
+		"Failed to parse ini file");
+
+	iniparser_dump(ini, stdout);
+	iniparser_freedict(ini);
+
+	ini = iniparser_load(ini_bad);
+	fail_if(ini != NULL,
+		"Failed to catch bad ini file");
+
+	iniparser_dump(ini, stdout);
+	iniparser_freedict(ini);
+}
+END_TEST
+
+static Suite *
+configurator_suite(void)
+{
+	Suite *s;
+	TCase *tc;
+
+	s = suite_create("configurator");
+
+	tc = tcase_create("compilation defaults");
+	tcase_add_test(tc, configurator_default_conf_file);
+	tcase_add_test(tc, configurator_default_module_dir);
+	tcase_add_test(tc, configurator_default_db_path);
+	tcase_add_test(tc, configurator_default_smack_load_file);
+	tcase_add_test(tc, configurator_default_buxton_socket);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("env clobbers defaults");
+	tcase_add_test(tc, configurator_env_conf_file);
+	tcase_add_test(tc, configurator_env_module_dir);
+	tcase_add_test(tc, configurator_env_db_path);
+	tcase_add_test(tc, configurator_env_smack_load_file);
+	tcase_add_test(tc, configurator_env_buxton_socket);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("command line clobbers all");
+	tcase_add_test(tc, configurator_cmd_conf_file);
+	tcase_add_test(tc, configurator_cmd_module_dir);
+	tcase_add_test(tc, configurator_cmd_db_path);
+	tcase_add_test(tc, configurator_cmd_smack_load_file);
+	tcase_add_test(tc, configurator_cmd_buxton_socket);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("config file works");
+	tcase_add_test(tc, configurator_conf_module_dir);
+	tcase_add_test(tc, configurator_conf_db_path);
+	tcase_add_test(tc, configurator_conf_smack_load_file);
+	tcase_add_test(tc, configurator_conf_buxton_socket);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("config file works");
+	tcase_add_test(tc, configurator_get_layers);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("ini_functions");
+	tcase_add_test(tc, ini_parse_check);
+	suite_add_tcase(s, tc);
+
+	return s;
+}
+
+int main(void)
+{
+	int number_failed;
+	Suite *s;
+	SRunner *sr;
+
+	s = configurator_suite();
+	sr = srunner_create(s);
+	srunner_run_all(sr, CK_VERBOSE);
+	number_failed = srunner_ntests_failed(sr);
+	srunner_free(sr);
+
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+/*
+ * Editor modelines  -  http://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: t
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 noexpandtab:
+ * :indentSize=8:tabSize=8:noTabs=false:
+ */

--- a/test/check_daemon.c
+++ b/test/check_daemon.c
@@ -1297,6 +1297,7 @@ int main(void)
 	Suite *s;
 	SRunner *sr;
 
+	putenv("BUXTON_CONF_FILE=" ABS_TOP_BUILDDIR "/test/test.conf");
 	s = daemon_suite();
 	sr = srunner_create(s);
 	srunner_run_all(sr, CK_VERBOSE);

--- a/test/check_smack.c
+++ b/test/check_smack.c
@@ -199,6 +199,7 @@ int main(void)
 	Suite *s;
 	SRunner *sr;
 
+	putenv("BUXTON_CONF_FILE=" ABS_TOP_BUILDDIR "/test/test.conf");
 	s = daemon_suite();
 	sr = srunner_create(s);
 	srunner_run_all(sr, CK_VERBOSE);

--- a/test/test-configurator.conf
+++ b/test/test-configurator.conf
@@ -1,0 +1,55 @@
+#
+# Test config for buxton configurator
+#
+
+[Configuration]
+ModuleDirectory=/shut/your/mouth
+DatabasePath=/you/are/so/suck
+SmackLoadFile=/smack/smack/smack
+SocketPath=/hurp/durp/durp
+
+[base]
+Type=System
+Backend=gdbm
+Description=Operating System configuration layer
+Priority=0
+# This will end up being a file at @@DB_PATH@@/base.db
+
+[isp]
+Type=System
+Backend=gdbm
+Description=ISP specific settings
+Priority=1
+# This will end up being a file at @@DB_PATH@@/isp.db
+
+[temp]
+Type=System
+Backend=memory
+Priority=99
+Description=A termporary layer for scratch settings and data
+# This will not end up in any file
+
+[user]
+Type=User
+Backend=gdbm
+Priority=1000
+Description=Per-user settings
+# This will end up in @@DB_PATH@@/user-<uid>.db
+
+[test-gdbm]
+Type=System
+Backend=gdbm
+Priority=5000
+Description="GDBM test db"
+
+[test-memory]
+Type=System
+Backend=memory
+Priority=5001
+Description="Memory test db"
+
+[test-gdbm-user]
+Type=User
+Backend=gdbm
+Priority=6000
+Description=GDBM test db for user

--- a/test/test.conf.in
+++ b/test/test.conf.in
@@ -2,6 +2,12 @@
 # Default buxton config file
 #
 
+[Configuration]
+ModuleDirectory=@abs_top_builddir@/.libs
+DatabasePath=@abs_top_builddir@/test/databases
+SmackLoadFile=@abs_top_srcdir@/test/test.load2
+SocketPath=@abs_top_builddir@/test/buxton-socket
+
 [base]
 Type=System
 Backend=gdbm


### PR DESCRIPTION
Configurator is great.  It replaces the usage of constants.[ch] to a
flexible system.  It also encapsulates the ini parser functionality to
one spot.  The tests are changed to more sensible directories.

Configurator introduces order of precedence for configuration items.
1) things added through the command line with buxton_add_cmd_line()
2) things in the environment
3) things in the conf file
4) compiled in defaults

Configurator also adds a section to the configuration file to store
these values.

Configurator improves your day and brightens your future

Signed-off-by: Michael Leibowitz michael.leibowitz@intel.com
