### PR TITLE
demo: Add GUI client demo

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -336,7 +336,8 @@ check_DATA = \
 
 if BUILD_DEMOS
 bin_PROGRAMS += \
-	bxt_timing
+	bxt_timing \
+	gtk_client
 
 # Timing test
 bxt_timing_SOURCES = \
@@ -345,4 +346,17 @@ bxt_timing_LDADD = \
 	libbuxton.la \
 	libbuxton-shared.la \
 	-lrt -lm
+
+# GTK3 client demo
+gtk_client_SOURCES = \
+	demo/gtk_client.c \
+	demo/gtk_client.h
+gtk_client_LDADD = \
+	$(GTK3_LIBS) \
+	libbuxton.la \
+	libbuxton-shared.la
+gtk_client_CFLAGS = \
+	$(GTK3_CFLAGS) \
+	$(AM_CFLAGS)
+
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -183,6 +183,11 @@ AS_IF([test "x$enable_demos" = "xyes"],
 	[])
 AM_CONDITIONAL([BUILD_DEMOS], [test x$enable_demos = x"yes"])
 
+if test "x$enable_demos" = "xyes"; then
+	# Require GTK3 for client demonstration
+	PKG_CHECK_MODULES([GTK3], [gtk+-3.0 >= 3.10])
+fi
+
 AC_CONFIG_COMMANDS([mkdir], [$MKDIR_P test/databases])
 AC_CONFIG_FILES([
 data/buxton.service

--- a/demo/gtk_client.c
+++ b/demo/gtk_client.c
@@ -1,0 +1,246 @@
+/*
+ * This file is part of buxton.
+ *
+ * Copyright (C) 2013 Intel Corporation
+ *
+ * buxton is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "bt-daemon.h"
+#include "gtk_client.h"
+
+/* BuxtonTest object */
+struct _BuxtonTest {
+        GtkWindow parent;
+        BuxtonClient client;
+        GtkWidget *info_label;
+        GtkWidget *info;
+        GtkWidget *value_label;
+        GtkWidget *entry;
+};
+
+/* BuxtonTest class definition */
+struct _BuxtonTestClass {
+        GtkWindowClass parent_class;
+};
+
+G_DEFINE_TYPE(BuxtonTest, buxton_test, GTK_TYPE_WINDOW)
+
+/* Boilerplate GObject code */
+static void buxton_test_class_init(BuxtonTestClass *klass);
+static void buxton_test_init(BuxtonTest *self);
+static void buxton_test_dispose(GObject *object);
+
+static void update_key(GtkWidget *self, gpointer userdata);
+static void update_value(BuxtonTest *self);
+static void report_error(BuxtonTest *self, gchar *error);
+static gboolean update_buxton(BuxtonTest *self);
+
+/* Initialisation */
+static void buxton_test_class_init(BuxtonTestClass *klass)
+{
+	GObjectClass *g_object_class;
+
+	g_object_class = G_OBJECT_CLASS(klass);
+	g_object_class->dispose = &buxton_test_dispose;
+}
+
+static void buxton_test_init(BuxtonTest *self)
+{
+	GtkWidget *header, *info, *layout;
+	GtkWidget *label, *container, *box, *box2;
+	GtkWidget *entry, *button;
+	GtkStyleContext *style;
+
+	/* Window setup */
+	g_signal_connect(self, "destroy", gtk_main_quit, NULL);
+	gtk_window_set_default_size(GTK_WINDOW(self), 700, 300);
+	gtk_window_set_title(GTK_WINDOW(self), "BuxtonTest");
+
+	/* layout */
+	layout = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+	gtk_container_add(GTK_CONTAINER(self), layout);
+
+	info = gtk_info_bar_new();
+	label = gtk_label_new("Connecting");
+	self->info_label = label;
+	self->info = info;
+	container = gtk_info_bar_get_content_area(GTK_INFO_BAR(info));
+	gtk_container_add(GTK_CONTAINER(container), label);
+	gtk_box_pack_start(GTK_BOX(layout), info, FALSE, FALSE, 0);
+
+	/* Help label */
+	label = gtk_label_new("<big>"
+		"Using the controls below, you can set a key within the\n"
+		"<b>base</b> layer. Open another instance of this client to\n"
+		"check notification support.</big>");
+	gtk_label_set_use_markup(GTK_LABEL(label), TRUE);
+	gtk_box_pack_start(GTK_BOX(layout), label, FALSE, FALSE, 10);
+
+	box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+	gtk_widget_set_valign(box, GTK_ALIGN_CENTER);
+	gtk_widget_set_halign(box, GTK_ALIGN_CENTER);
+	gtk_box_pack_start(GTK_BOX(layout), box, TRUE, TRUE, 0);
+
+	/* Updated to key value */
+	label = gtk_label_new("<big>\'test\' value:</big>");
+	self->value_label = label;
+	gtk_label_set_use_markup(GTK_LABEL(label), TRUE);
+	gtk_box_pack_start(GTK_BOX(box), label, FALSE, FALSE, 10);
+
+	box2 = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+	style = gtk_widget_get_style_context(box2);
+	gtk_style_context_add_class(style, GTK_STYLE_CLASS_LINKED);
+	gtk_box_pack_start(GTK_BOX(box), box2, TRUE, TRUE, 0);
+
+	/* Give entry and button a linked effect */
+	entry = gtk_entry_new();
+	self->entry = entry;
+	gtk_entry_set_placeholder_text(GTK_ENTRY(self->entry),
+		"Type a new value");
+	g_signal_connect(entry, "activate", G_CALLBACK(update_key), self);
+	gtk_box_pack_start(GTK_BOX(box2), entry, TRUE, TRUE, 0);
+
+	button = gtk_button_new_with_label("Update");
+	g_signal_connect(button, "clicked", G_CALLBACK(update_key), self);
+	gtk_box_pack_start(GTK_BOX(box2), button, FALSE, FALSE, 0);
+
+	/* Integrate with Mutter based desktops */
+	header = gtk_header_bar_new();
+	gtk_header_bar_set_title(GTK_HEADER_BAR(header), "BuxtonTest");
+	gtk_header_bar_set_show_close_button(GTK_HEADER_BAR(header), TRUE);
+	gtk_window_set_titlebar(GTK_WINDOW(self), header);
+
+	gtk_widget_show_all(GTK_WIDGET(self));
+	gtk_widget_grab_focus(button);
+
+	/* Attempt connection to Buxton */
+	if (!buxton_client_open(&self->client)) {
+		gtk_info_bar_set_message_type(GTK_INFO_BAR(info),
+			GTK_MESSAGE_ERROR);
+		gtk_label_set_markup(GTK_LABEL(self->info_label), "No connection!");
+		gtk_widget_show(info);
+	} else {
+		/* TODO: Register for notifications */
+		gtk_widget_hide(info);
+	}
+
+	 update_value(self);
+	 /* Grab buxton notifications on idle loop */
+	 g_idle_add(update_buxton, self);
+}
+
+static void buxton_test_dispose(GObject *object)
+{
+	BuxtonTest *self = BUXTON_TEST(object);
+	buxton_client_close(&self->client);
+
+        /* Destruct */
+        G_OBJECT_CLASS (buxton_test_parent_class)->dispose (object);
+}
+
+/* Utility; return a new BuxtonTest */
+GtkWidget* buxton_test_new(void)
+{
+	BuxtonTest *self;
+
+	self = g_object_new(BUXTON_TEST_TYPE, NULL);
+	return GTK_WIDGET(self);
+}
+
+static void update_key(GtkWidget *widget, gpointer userdata)
+{
+	BuxtonTest *self = BUXTON_TEST(userdata);
+	BuxtonData data;
+	BuxtonString *key;
+	BuxtonString layer;
+	BuxtonString value;
+	char *layer_name = "base";
+	const gchar *t_value;
+
+
+	t_value = gtk_entry_get_text(GTK_ENTRY(self->entry));
+	if (strlen(t_value) == 0 || g_str_equal(t_value, ""))
+		return;
+
+	key = buxton_make_key("test", "test");
+	layer.value = layer_name;
+	layer.length = (uint32_t)strlen(layer_name)+1;
+
+	/* Set data */
+	value.value = (char*)t_value;
+	value.length = (uint32_t)strlen(t_value)+1;
+	buxton_string_to_data(&value, &data);
+
+	/* Clients should **not** be setting their own smack label */
+	data.label.value = "_";
+	data.label.length = 2;
+
+	if (!buxton_client_set_value(&self->client, &layer, key, &data))
+		report_error(self, "Unable to set value!");
+	else
+		update_value(self);
+	free(key);
+}
+
+static void update_value(BuxtonTest *self)
+{
+	BuxtonData data;
+	BuxtonString *key;
+	gchar *lab;
+
+	key = buxton_make_key("test", "test");
+
+	if (!buxton_client_get_value(&self->client, key, &data)) {
+		/* Buxton disconnects us when this happens. ##FIXME##
+		 * We force a reconnect */
+		report_error(self, "Cannot retrieve value");
+		buxton_client_close(&self->client);
+		if (!buxton_client_open(&self->client))
+			report_error(self, "Unable to connect to Buxton!");
+		return;
+	}
+
+	lab = g_strdup_printf("<big>\'test\' value: %s</big>", data.store.d_string.value);
+	gtk_label_set_markup(GTK_LABEL(self->value_label), lab);
+	free(lab);
+
+	free(key);
+}
+
+static void report_error(BuxtonTest *self, gchar *error)
+{
+	if (error != NULL) {
+		printf("Error! %s\n", error);
+		gtk_label_set_markup(GTK_LABEL(self->info_label), error);
+		gtk_widget_show_all(GTK_WIDGET(self->info));
+		gtk_info_bar_set_message_type(GTK_INFO_BAR(self->info),
+			GTK_MESSAGE_ERROR);
+	} else {
+		gtk_widget_hide(GTK_WIDGET(self->info));
+	}
+}
+
+static gboolean update_buxton(BuxtonTest *self)
+{
+	/* TODO: Probe for notifications */
+	return TRUE;
+}
+
+/** Main entry */
+int main(int argc, char **argv)
+{
+	__attribute__ ((unused)) GtkWidget *window = NULL;
+
+	gtk_init(&argc, &argv);
+	window = buxton_test_new();
+	gtk_main();
+
+	return EXIT_SUCCESS;
+}

--- a/demo/gtk_client.h
+++ b/demo/gtk_client.h
@@ -1,0 +1,30 @@
+/*
+ * This file is part of buxton.
+ *
+ * Copyright (C) 2013 Intel Corporation
+ *
+ * buxton is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include <glib-object.h>
+#include <gtk/gtk.h>
+
+typedef struct _BuxtonTest BuxtonTest;
+typedef struct _BuxtonTestClass   BuxtonTestClass;
+
+#define BUXTON_TEST_TYPE (buxton_test_get_type())
+#define BUXTON_TEST(obj)                  (G_TYPE_CHECK_INSTANCE_CAST ((obj), BUXTON_TEST_TYPE, BuxtonTest))
+#define IS_BUXTON_TEST(obj)               (G_TYPE_CHECK_INSTANCE_TYPE ((obj), BUXTON_TEST_TYPE))
+#define BUXTON_TEST_CLASS(klass)          (G_TYPE_CHECK_CLASS_CAST ((klass), BUXTON_TEST_TYPE, BuxtonTestClass))
+#define IS_BUXTON_TEST_CLASS(klass)       (G_TYPE_CHECK_CLASS_TYPE ((klass), BUXTON_TEST_TYPE))
+#define BUXTON_TEST_GET_CLASS(obj)        (G_TYPE_INSTANCE_GET_CLASS ((obj), BUXTON_TEST_TYPE, BuxtonTestClass))
+
+GType buxton_test_get_type(void);
+
+/* BuxtonTest methods */
+GtkWidget* buxton_test_new(void);


### PR DESCRIPTION
Added a demo program here, as I haven't the hardware required to convert specified programs.
This is using GTK3, has a method in place on GTK's main loop to probe notification, even though we don't do that yet. It shows how a purely client program can be implemented, and raises any potential issues to the surface.

Such as being disconnected when get_value fails from an unknown key, the overly verbose methodology to set a key, and the issue with clients setting their own smack labels. This needs to be done inside the library and before it hits the serialize function (which causes the assert)
