### PR TITLE
Initial add of error handling

### DIFF
--- a/src/core/daemon.h
+++ b/src/core/daemon.h
@@ -87,7 +87,7 @@ bool parse_list(BuxtonControlMessage msg, size_t count, BuxtonData *list,
  * @param size Size of the data being handled
  * @returns bool True if message was successfully handled
  */
-bool bt_daemon_handle_message(BuxtonDaemon *self,
+ssize_t bt_daemon_handle_message(BuxtonDaemon *self,
 			      client_list_item *client,
 			      size_t size)
 	__attribute__((warn_unused_result));

--- a/src/libbuxton/lbuxton.sym
+++ b/src/libbuxton/lbuxton.sym
@@ -23,6 +23,7 @@ BUXTON_1 {
 		response_type;
 		response_key;
 		response_value;
+		buxton_strerror;
 	local:
 		*;
 };

--- a/src/shared/buxtonarray.c
+++ b/src/shared/buxtonarray.c
@@ -24,18 +24,18 @@ BuxtonArray *buxton_array_new(void)
 	return ret;
 }
 
-bool buxton_array_add(BuxtonArray *array,
+ssize_t buxton_array_add(BuxtonArray *array,
 		      void *data)
 {
 	uint new_len;
 	size_t curr, new_size;
 
 	if (!array || !data)
-		return false;
+		return -BUXTON_STATUS_BAD_ARGS;
 	if (!array->data) {
 		array->data = calloc(1, sizeof(void*));
 		if (!array->data)
-			return false;
+			return -BUXTON_STATUS_OOM;
 	}
 
 	new_len = array->len += 1;
@@ -45,12 +45,12 @@ bool buxton_array_add(BuxtonArray *array,
 		/* Resize the array to hold one more pointer */
 		array->data = greedy_realloc((void**)&array->data, &curr, new_size);
 		if (!array->data)
-			return false;
+			return -BUXTON_STATUS_OOM;
 	}
 	/* Store the pointer at the end of the array */
 	array->len = new_len;
 	array->data[array->len-1] = data;
-	return true;
+	return BUXTON_STATUS_OK;
 }
 
 void *buxton_array_get(BuxtonArray *array, uint16_t index)

--- a/src/shared/buxtonarray.h
+++ b/src/shared/buxtonarray.h
@@ -47,9 +47,10 @@ BuxtonArray *buxton_array_new(void)
  * Append data to BuxtonArray
  * @param array Valid BuxtonArray
  * @param data Pointer to add to this array
- * @returns bool true if the data was added to the array
+ * @returns bool 0 if the data was added to the array, or -(BuxtonStatus)
+ *      on error
  */
-bool buxton_array_add(BuxtonArray *array,
+ssize_t buxton_array_add(BuxtonArray *array,
 		      void *data)
 	__attribute__((warn_unused_result));
 

--- a/src/shared/protocol.h
+++ b/src/shared/protocol.h
@@ -61,9 +61,9 @@ void run_callback(BuxtonCallback callback, void *data, size_t count,
  * @param data User data passed to callback function
  * @param msgid Message id used to identify bt-daemon's response
  * @param type The type of request being sent to bt-daemon
- * @return a boolean value, indicating success of the operation
+ * @return 0 on success, -(BuxtonStatus) on failure
  */
-bool send_message(_BuxtonClient *client, uint8_t *send, size_t send_len,
+ssize_t send_message(_BuxtonClient *client, uint8_t *send, size_t send_len,
 		  BuxtonCallback callback, void *data, uint64_t msgid,
 		  BuxtonControlMessage type, _BuxtonKey *key)
 	__attribute__((warn_unused_result));
@@ -81,7 +81,8 @@ void handle_callback_response(BuxtonControlMessage msg, uint64_t msgid,
 /**
  * Parse responses from bt-daemon and run callbacks on received messages
  * @param client A BuxtonClient
- * @return number of received messages processed
+ * @return number of received messages processed, or a -(BuxtonStatus) on
+ *     error
  */
 
 ssize_t buxton_wire_handle_response(_BuxtonClient *client)
@@ -92,7 +93,7 @@ ssize_t buxton_wire_handle_response(_BuxtonClient *client)
  * @param client Client connection
  * @return a boolean value, indicating success of the operation
  */
-bool buxton_wire_get_response(_BuxtonClient *client);
+ssize_t buxton_wire_get_response(_BuxtonClient *client);
 
 /**
  * Send a SET message over the wire protocol, return the response
@@ -102,9 +103,10 @@ bool buxton_wire_get_response(_BuxtonClient *client);
  * @param data A BuxtonData storing the new value
  * @param callback A callback function to handle daemon reply
  * @param data User data to be used with callback function
- * @return a boolean value, indicating success of the operation
+ * @return a ssize_t value, indicating success of the operation or
+         a -(BuxtonStatus) reason for failure
  */
-bool buxton_wire_set_value(_BuxtonClient *client, _BuxtonKey *key, void *value,
+ssize_t buxton_wire_set_value(_BuxtonClient *client, _BuxtonKey *key, void *value,
 			   BuxtonCallback callback, void *data)
 	__attribute__((warn_unused_result));
 
@@ -118,9 +120,9 @@ bool buxton_wire_set_value(_BuxtonClient *client, _BuxtonKey *key, void *value,
  * @param value Key or group label
  * @param callback A callback function to handle daemon reply
  * @param data User data to be used with callback function
- * @return a boolean value, indicating success of the operation
+ * @return 0 on success, -(BuxtonStatus) on failure
  */
-bool buxton_wire_set_label(_BuxtonClient *client, _BuxtonKey *key,
+ssize_t buxton_wire_set_label(_BuxtonClient *client, _BuxtonKey *key,
 			   BuxtonString *value, BuxtonCallback callback,
 			   void *data)
 	__attribute__((warn_unused_result));
@@ -134,9 +136,9 @@ bool buxton_wire_set_label(_BuxtonClient *client, _BuxtonKey *key,
  * @param key Key with group and layer members initialized
  * @param callback A callback function to handle daemon reply
  * @param data User data to be used with callback function
- * @return a boolean value, indicating success of the operation
+ * @return 0 on success, -(BuxtonStatus) on failure
  */
-bool buxton_wire_create_group(_BuxtonClient *client, _BuxtonKey *key,
+ssize_t buxton_wire_create_group(_BuxtonClient *client, _BuxtonKey *key,
 			      BuxtonCallback callback, void *data)
 	__attribute__((warn_unused_result));
 
@@ -146,9 +148,9 @@ bool buxton_wire_create_group(_BuxtonClient *client, _BuxtonKey *key,
  * @param key _BuxtonKey pointer
  * @param callback A callback function to handle daemon reply
  * @param data User data to be used with callback functionb
- * @return a boolean value, indicating success of the operation
+ * @return 0 on success, -(BuxtonStatus) on failure
  */
-bool buxton_wire_get_value(_BuxtonClient *client, _BuxtonKey *key,
+ssize_t buxton_wire_get_value(_BuxtonClient *client, _BuxtonKey *key,
 			   BuxtonCallback callback, void *data)
 	__attribute__((warn_unused_result));
 
@@ -159,9 +161,9 @@ bool buxton_wire_get_value(_BuxtonClient *client, _BuxtonKey *key,
  * @param key _BuxtonKey pointer
  * @param callback A callback function to handle daemon reply
  * @param data User data to be used with callback function
- * @return a boolean value, indicating success of the operation
+ * @return 0 on success, -(BuxtonStatus) on failure
  */
-bool buxton_wire_unset_value(_BuxtonClient *client,
+ssize_t buxton_wire_unset_value(_BuxtonClient *client,
 			     _BuxtonKey *key,
 			     BuxtonCallback callback,
 			     void *data)
@@ -172,9 +174,9 @@ bool buxton_wire_unset_value(_BuxtonClient *client,
  * @param key _BuxtonKey pointer
  * @param callback A callback function to handle daemon reply
  * @param data User data to be used with callback function
- * @return a boolean value, indicating success of the operation
+ * @return 0 on success, -(BuxtonStatus) on failure
  */
-bool buxton_wire_register_notification(_BuxtonClient *client,
+ssize_t buxton_wire_register_notification(_BuxtonClient *client,
 				       _BuxtonKey *key,
 				       BuxtonCallback callback,
 				       void *data)
@@ -188,7 +190,7 @@ bool buxton_wire_register_notification(_BuxtonClient *client,
  * @param data User data to be used with callback function
  * @return a boolean value, indicating success of the operation
  */
-bool buxton_wire_list_keys(_BuxtonClient *client,
+ssize_t buxton_wire_list_keys(_BuxtonClient *client,
 			   BuxtonString *layer,
 			   BuxtonCallback callback,
 			   void *data)
@@ -202,7 +204,7 @@ bool buxton_wire_list_keys(_BuxtonClient *client,
  * @param data User data to be used with callback function
  * @return a boolean value, indicating success of the operation
  */
-bool buxton_wire_unregister_notification(_BuxtonClient *client,
+ssize_t buxton_wire_unregister_notification(_BuxtonClient *client,
 					 _BuxtonKey *key,
 					 BuxtonCallback callback,
 					 void *data)

--- a/src/shared/serialize.h
+++ b/src/shared/serialize.h
@@ -87,9 +87,10 @@ bool buxton_deserialize(uint8_t *source, BuxtonData *target,
  * @param message The type of message to be serialized
  * @param msgid The message ID to be serialized
  * @param list An array of BuxtonData's to be serialized
- * @return a size_t, 0 indicates failure otherwise size of dest
+ * @return a size_t, 0 indicates success, <0 is an error code (BuxtonStatus),
+     and >= 0 indicates success  and is the size of the serialized msg
  */
-size_t buxton_serialize_message(uint8_t **dest,
+ssize_t buxton_serialize_message(uint8_t **dest,
 				BuxtonControlMessage message,
 				uint64_t msgid,
 				BuxtonArray *list)
@@ -104,7 +105,7 @@ size_t buxton_serialize_message(uint8_t **dest,
  * @param list A pointer that will be filled out as an array of BuxtonData structs
  * @return the length of the array, or 0 if deserialization failed
  */
-size_t buxton_deserialize_message(uint8_t *data,
+ssize_t buxton_deserialize_message(uint8_t *data,
 				  BuxtonControlMessage *r_message,
 				  size_t size, uint64_t *r_msgid,
 				  BuxtonData **list)
@@ -114,7 +115,8 @@ size_t buxton_deserialize_message(uint8_t *data,
  * Get size of a buxton message data stream
  * @param data The source data stream
  * @param size The size of the data stream (from read)
- * @return a size_t length of the complete message or 0
+ * @return a size_t length of the complete message or a -(BuxtonStatus)
+ *     on error
  */
 size_t buxton_get_message_size(uint8_t *data, size_t size)
 	__attribute__((warn_unused_result));


### PR DESCRIPTION
This is a first-pass for a sane error handling scheme. Adds
ssize_t returns to all (currently, most) client calls, and adds
a new client call for looking up error codes:

  const char *buxton_strerror(ssize_t code)
