### PR TITLE
Initial addition of server-side error handling support. Client-side is in progress

### DIFF
--- a/demo/gtk_client.c
+++ b/demo/gtk_client.c
@@ -268,7 +268,7 @@ static void buxton_callback(BuxtonResponse response, gpointer userdata)
 	self = BUXTON_TEST(userdata);
 
         /* Handle all potential async cases we're utilizing */
-        if (response_status(response) != BUXTON_STATUS_OK) {
+        if (response_status(response) != 0) {
                 switch (response_type(response)) {
                         case BUXTON_CONTROL_GET:
                                 report_error(self, "Cannot retrieve value");

--- a/demo/helloget.c
+++ b/demo/helloget.c
@@ -21,7 +21,7 @@ void get_cb(BuxtonResponse response, void *data)
 {
 	int32_t* ret = (int32_t*)data;
 
-	if (response_status(response) != BUXTON_STATUS_OK) {
+	if (response_status(response) != 0) {
 		printf("Failed to get value\n");
 		return;
 	}

--- a/demo/helloset.c
+++ b/demo/helloset.c
@@ -22,7 +22,7 @@ void set_cb(BuxtonResponse response, void *data)
 	BuxtonKey key;
 	char *name;
 
-	if (response_status(response) != BUXTON_STATUS_OK) {
+	if (response_status(response) != 0) {
 		printf("Failed to set value\n");
 		return;
 	}

--- a/demo/timing.c
+++ b/demo/timing.c
@@ -31,7 +31,7 @@ static void callback(BuxtonResponse response, void *userdata)
 
 	r = (bool *)userdata;
 
-	if (response_status(response) == BUXTON_STATUS_OK)
+	if (response_status(response) == 0)
 		*r = true;
 }
 

--- a/src/cli/client.c
+++ b/src/cli/client.c
@@ -272,7 +272,7 @@ void get_value_callback(BuxtonResponse response, void *data)
 	BuxtonData *r = (BuxtonData *)data;
 	void *p;
 
-	if (response_status(response) != BUXTON_STATUS_OK)
+	if (response_status(response) != 0)
 		return;
 
 	p = response_value(response);
@@ -435,7 +435,7 @@ static void list_keys_callback(BuxtonResponse response, void *data)
 	BuxtonArray *array = r->data;
 	BuxtonData *d;
 	//FIXME change to use api (make api first)
-	if (response_status(response) != BUXTON_STATUS_OK)
+	if (response_status(response) != 0)
 		return;
 
 	BuxtonString *layer = (BuxtonString *)data;

--- a/src/core/daemon.h
+++ b/src/core/daemon.h
@@ -87,7 +87,7 @@ bool parse_list(BuxtonControlMessage msg, size_t count, BuxtonData *list,
  * @param size Size of the data being handled
  * @returns bool True if message was successfully handled
  */
-bool bt_daemon_handle_message(BuxtonDaemon *self,
+int32_t bt_daemon_handle_message(BuxtonDaemon *self,
 			      client_list_item *client,
 			      size_t size)
 	__attribute__((warn_unused_result));
@@ -108,10 +108,10 @@ void bt_daemon_notify_clients(BuxtonDaemon *self, client_list_item *client,
  * @param client Used to validate smack access
  * @param key Key for the value being set
  * @param value Value being set
- * @param status Will be set with the BuxtonStatus result of the operation
+ * @param status Will be set with the int32_t result of the operation
  */
 void set_value(BuxtonDaemon *self, client_list_item *client,
-	       _BuxtonKey *key, BuxtonData *value, BuxtonStatus *status);
+	       _BuxtonKey *key, BuxtonData *value, int32_t *status);
 
 /**
  * Buxton daemon function for setting a label
@@ -119,41 +119,41 @@ void set_value(BuxtonDaemon *self, client_list_item *client,
  * @param client Used to validate smack access
  * @param key Key or group for the label being set
  * @param value Label being set
- * @param status Will be set with the BuxtonStatus result of the operation
+ * @param status Will be set with the int32_t result of the operation
  */
 void set_label(BuxtonDaemon *self, client_list_item *client,
-	       _BuxtonKey *key, BuxtonData *value, BuxtonStatus *status);
+	       _BuxtonKey *key, BuxtonData *value, int32_t *status);
 
 /**
  * Buxton daemon function for creating a group
  * @param self bt-daemon instance being run
  * @param client Used to validate smack access
  * @param key Key with layer and group members initialized
- * @param status Will be set with the BuxtonStatus result of the operation
+ * @param status Will be set with the int32_t result of the operation
  */
 void create_group(BuxtonDaemon *self, client_list_item *client,
-		  _BuxtonKey *key, BuxtonStatus *status);
+		  _BuxtonKey *key, int32_t *status);
 
 /**
  * Buxton daemon function for removing a group
  * @param self bt-daemon instance being run
  * @param client Used to validate smack access
  * @param key Key with layer and group members initialized
- * @param status Will be set with the BuxtonStatus result of the operation
+ * @param status Will be set with the int32_t result of the operation
  */
 void remove_group(BuxtonDaemon *self, client_list_item *client,
-		  _BuxtonKey *key, BuxtonStatus *status);
+		  _BuxtonKey *key, int32_t *status);
 
 /**
  * Buxton daemon function for getting a value
  * @param self bt-daemon instance being run
  * @param client Used to validate smack access
  * @param key Key for the value being sought
- * @param status Will be set with the BuxtonStatus result of the operation
+ * @param status Will be set with the int32_t result of the operation
  * @returns BuxtonData Value stored for key if successful otherwise NULL
  */
 BuxtonData *get_value(BuxtonDaemon *self, client_list_item *client,
-		      _BuxtonKey *key, BuxtonStatus *status)
+		      _BuxtonKey *key, int32_t *status)
 	__attribute__((warn_unused_result));
 
 /**
@@ -161,20 +161,20 @@ BuxtonData *get_value(BuxtonDaemon *self, client_list_item *client,
  * @param self bt-daemon instance being run
  * @param client Used to validate smack access
  * @param key Key for the value being dunset
- * @param status Will be set with the BuxtonStatus result of the operation
+ * @param status Will be set with the int32_t result of the operation
  */
 void unset_value(BuxtonDaemon *self, client_list_item *client,
-		 _BuxtonKey *key, BuxtonStatus *status);
+		 _BuxtonKey *key, int32_t *status);
 
 /**
  * Buxton daemon function for listing keys in a given layer
  * @param self bt-daemon instance being run
  * @param client Used to validate smack access
  * @param layer Layer to query
- * @param status Will be set with the BuxtonStatus result of the operation
+ * @param status Will be set with the int32_t result of the operation
  */
 BuxtonArray *list_keys(BuxtonDaemon *self, client_list_item *client,
-		       BuxtonString *layer, BuxtonStatus *status)
+		       BuxtonString *layer, int32_t *status)
 	__attribute__((warn_unused_result));
 
 /**
@@ -183,22 +183,22 @@ BuxtonArray *list_keys(BuxtonDaemon *self, client_list_item *client,
  * @param client Used to validate smack access
  * @param key Key to notify for changes on
  * @param msgid Message ID from the client
- * @param status Will be set with the BuxtonStatus result of the operation
+ * @param status Will be set with the int32_t result of the operation
  */
 void register_notification(BuxtonDaemon *self, client_list_item *client,
 			   _BuxtonKey *key, uint64_t msgid,
-			   BuxtonStatus *status);
+			   int32_t *status);
 
 /**
  * Buxton daemon function for unregistering notifications from the given key
  * @param self bt-daemon instance being run
  * @param client Used to validate smack access
  * @param key Key to no longer recieve notifications for
- * @param status Will be set with the BuxtonStatus result of the operation
+ * @param status Will be set with the int32_t result of the operation
  * @return Message ID used to send key's notifications to the client
  */
 uint64_t unregister_notification(BuxtonDaemon *self, client_list_item *client,
-				 _BuxtonKey *key, BuxtonStatus *status)
+				 _BuxtonKey *key, int32_t *status)
 	__attribute__((warn_unused_result));
 
 /**

--- a/src/include/buxton.h
+++ b/src/include/buxton.h
@@ -76,14 +76,6 @@ typedef enum BuxtonControlMessage {
 } BuxtonControlMessage;
 
 /**
- * Buxton Status Codes
- */
-typedef enum BuxtonStatus {
-	BUXTON_STATUS_OK = 0, /**<Operation succeeded */
-	BUXTON_STATUS_FAILED /**<Operation failed */
-} BuxtonStatus;
-
-/**
  * Used to communicate with Buxton
  */
 typedef struct BuxtonClient *BuxtonClient;
@@ -353,9 +345,9 @@ _bx_export_ BuxtonControlMessage response_type(BuxtonResponse response)
 /**
  * Get the status of a buxton response
  * @param response a BuxtonResponse
- * @return BuxtonStatus enum indicating the status of the response
+ * @return int32_t enum indicating the status of the response
  */
-_bx_export_ BuxtonStatus response_status(BuxtonResponse response)
+_bx_export_ int response_status(BuxtonResponse response)
 	__attribute__((warn_unused_result));
 
 /**

--- a/src/libbuxton/lbuxton.c
+++ b/src/libbuxton/lbuxton.c
@@ -117,7 +117,7 @@ bool buxton_client_get_value(BuxtonClient client,
 			     void *data,
 			     bool sync)
 {
-	bool r;
+	bool r = false;
 	_BuxtonKey *k = (_BuxtonKey *)key;
 
 	if (!k || !(k->group.value) || !(k->name.value) ||
@@ -459,7 +459,7 @@ BuxtonControlMessage response_type(BuxtonResponse response)
 	return r->type;
 }
 
-BuxtonStatus response_status(BuxtonResponse response)
+int response_status(BuxtonResponse response)
 {
 	BuxtonData *d;
 	_BuxtonResponse *r = (_BuxtonResponse *)response;
@@ -468,12 +468,12 @@ BuxtonStatus response_status(BuxtonResponse response)
 		return -1;
 
 	if (response_type(response) == BUXTON_CONTROL_CHANGED)
-		return BUXTON_STATUS_OK;
+		return 0;
 
 	d = buxton_array_get(r->data, 0);
 
 	if (d)
-		return d->store.d_int32;
+		return (int) d->store.d_int32;
 
 	return -1;
 }

--- a/src/shared/direct.c
+++ b/src/shared/direct.c
@@ -15,6 +15,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <errno.h>
 
 #include "direct.h"
 #include "log.h"
@@ -38,7 +39,7 @@ bool buxton_direct_open(BuxtonControl *control)
 	return true;
 }
 
-bool buxton_direct_get_value(BuxtonControl *control, _BuxtonKey *key,
+int32_t buxton_direct_get_value(BuxtonControl *control, _BuxtonKey *key,
 			     BuxtonData *data, BuxtonString *data_label,
 			     BuxtonString *client_label)
 {
@@ -49,7 +50,7 @@ bool buxton_direct_get_value(BuxtonControl *control, _BuxtonKey *key,
 	Iterator i;
 	BuxtonData d;
 	int priority = 0;
-	int r;
+	int32_t r = ENOENT;
 	BuxtonLayerType layer_origin = -1;
 
 	assert(control);
@@ -103,10 +104,10 @@ bool buxton_direct_get_value(BuxtonControl *control, _BuxtonKey *key,
 		key->layer.length = 0;
 		return r;
 	}
-	return false;
+	return r;
 }
 
-bool buxton_direct_get_value_for_layer(BuxtonControl *control,
+int32_t buxton_direct_get_value_for_layer(BuxtonControl *control,
 				       _BuxtonKey *key,
 				       BuxtonData *data,
 				       BuxtonString *data_label,
@@ -119,7 +120,7 @@ bool buxton_direct_get_value_for_layer(BuxtonControl *control,
 	BuxtonData g;
 	_BuxtonKey group;
 	BuxtonString group_label;
-	bool r = false;
+	int32_t ret = -1;
 
 	assert(control);
 	assert(key);
@@ -132,8 +133,10 @@ bool buxton_direct_get_value_for_layer(BuxtonControl *control,
 
 	config = &control->config;
 	if ((layer = hashmap_get(config->layers, key->layer.value)) == NULL) {
+		ret = ENOENT;
 		goto fail;
 	}
+
 	backend = backend_for_layer(config, layer);
 	if (!backend) {
 		/* Already logged */
@@ -145,16 +148,21 @@ bool buxton_direct_get_value_for_layer(BuxtonControl *control,
 	if (key->name.value) {
 		if (!buxton_copy_key_group(key, &group))
 			goto fail;
-		if (!buxton_direct_get_value_for_layer(control, &group, &g, &group_label, NULL)) {
-			buxton_debug("Group %s for name %s missing for get value\n", key->group.value, key->name.value);
+
+		ret = buxton_direct_get_value_for_layer(control, &group, &g, &group_label, NULL);
+		if (ret) {
+			buxton_debug("Group %s for name %s missing for get value\n",
+						key->group.value, key->name.value);
 			goto fail;
 		}
 	}
 
 	/* The group checks are only needed for key lookups, or we recurse endlessly */
 	if (key->name.value && client_label)
-		if (!buxton_check_smack_access(client_label, &group_label, ACCESS_READ))
+		if (!buxton_check_smack_access(client_label, &group_label, ACCESS_READ)) {
+			ret = EPERM;
 			goto fail;
+		}
 
 	if (backend->get_value(layer, key, data, data_label)) {
 		/* Access checks are not needed for direct clients, where client_label is NULL */
@@ -162,20 +170,19 @@ bool buxton_direct_get_value_for_layer(BuxtonControl *control,
 		    !buxton_check_smack_access(client_label, data_label, ACCESS_READ)) {
 			/* Client lacks permission to read the value */
 			free(data_label->value);
+			ret = EPERM;
 			goto fail;
 		}
 		buxton_debug("SMACK check succeeded for get_value for layer %s\n", key->layer.value);
-		r = true;
-	} else {
-		goto fail;
+		ret = 0;
 	}
 
 fail:
 	buxton_debug("get_value for layer end\n");
-	return r;
+	return ret;
 }
 
-bool buxton_direct_set_value(BuxtonControl *control,
+int32_t buxton_direct_set_value(BuxtonControl *control,
 			     _BuxtonKey *key,
 			     BuxtonData *data,
 			     BuxtonString *label)
@@ -190,7 +197,7 @@ bool buxton_direct_set_value(BuxtonControl *control,
 	_cleanup_buxton_key_ _BuxtonKey *group = NULL;
 	_cleanup_buxton_string_ BuxtonString *data_label = NULL;
 	_cleanup_buxton_string_ BuxtonString *group_label = NULL;
-	bool r = false;
+	int32_t ret = -1;
 
 	assert(control);
 	assert(key);
@@ -219,17 +226,22 @@ bool buxton_direct_set_value(BuxtonControl *control,
 	if (!buxton_copy_key_group(key, group))
 		goto fail;
 
-	if (!buxton_direct_get_value_for_layer(control, group, g, group_label, NULL)) {
-		buxton_debug("Group %s for name %s missing for set value\n", key->group.value, key->name.value);
+	ret = buxton_direct_get_value_for_layer(control, group, g, group_label, NULL);
+	if (ret != 0) {
+		buxton_debug("Group %s for name %s missing for set value, returned error code: %d\n", key->group.value, key->name.value, ret);
 		goto fail;
 	}
 
 	/* Access checks are not needed for direct clients, where label is NULL */
 	if (label) {
-		if (!buxton_check_smack_access(label, group_label, ACCESS_WRITE))
+		if (!buxton_check_smack_access(label, group_label, ACCESS_WRITE)) {
+			ret = EPERM;
 			goto fail;
-		if (buxton_direct_get_value_for_layer(control, key, d, data_label, NULL)) {
+		}
+		ret = buxton_direct_get_value_for_layer(control, key, d, data_label, NULL);
+		if (ret == 0) {
 			if (!buxton_check_smack_access(label, data_label, ACCESS_WRITE)) {
+				ret = EPERM;
 				goto fail;
 			}
 			l = data_label;
@@ -237,7 +249,8 @@ bool buxton_direct_set_value(BuxtonControl *control,
 			l = label;
 		}
 	} else {
-		if (buxton_direct_get_value_for_layer(control, key, d, data_label, NULL)) {
+		ret = buxton_direct_get_value_for_layer(control, key, d, data_label, NULL);
+		if (ret == 0) {
 			l = data_label;
 		} else {
 			l = &default_label;
@@ -255,14 +268,14 @@ bool buxton_direct_set_value(BuxtonControl *control,
 	}
 
 	layer->uid = control->client.uid;
-	r = backend->set_value(layer, key, data, l);
+	ret = backend->set_value(layer, key, data, l);
 
 fail:
 	buxton_debug("set_value end\n");
-	return r;
+	return ret;
 }
 
-bool buxton_direct_set_label(BuxtonControl *control,
+int32_t buxton_direct_set_label(BuxtonControl *control,
 			     _BuxtonKey *key,
 			     BuxtonString *label)
 {
@@ -271,7 +284,7 @@ bool buxton_direct_set_label(BuxtonControl *control,
 	BuxtonConfig *config;
 	_cleanup_buxton_data_ BuxtonData *data = NULL;
 	_cleanup_buxton_string_ BuxtonString *data_label = NULL;
-	bool r = false;
+	int32_t ret = -1;
 
 	assert(control);
 	assert(key);
@@ -296,11 +309,13 @@ bool buxton_direct_set_label(BuxtonControl *control,
 
 		/* FIXME: should check client's capability set instead of UID */
 		if (control->client.uid != 0 && !skip_check) {
+			ret = EPERM;
 			buxton_debug("Not permitted to create group '%s'\n", key->group.value);
 			goto fail;
 		}
 	} else {
 		buxton_debug("Cannot set labels in a user layer\n");
+		ret = EPERM;
 		goto fail;
 	}
 
@@ -310,9 +325,10 @@ bool buxton_direct_set_label(BuxtonControl *control,
 		goto fail;
 	}
 
-	r = buxton_direct_get_value_for_layer(control, key, data, data_label, NULL);
-	if (!r) {
+	ret = buxton_direct_get_value_for_layer(control, key, data, data_label, NULL);
+	if (ret) {
 		buxton_debug("Group or key does not exist\n");
+		ret = ENOENT;
 		goto fail;
 	}
 
@@ -324,15 +340,15 @@ bool buxton_direct_set_label(BuxtonControl *control,
 	}
 
 	layer->uid = control->client.uid;
-	r = backend->set_value(layer, key, data, data_label);
-	if (!r)
+	ret = backend->set_value(layer, key, data, data_label);
+	if (ret)
 		buxton_debug("set label failed\n");
 
 fail:
-	return r;
+	return ret;
 }
 
-bool buxton_direct_create_group(BuxtonControl *control,
+int32_t buxton_direct_create_group(BuxtonControl *control,
 				_BuxtonKey *key,
 				BuxtonString *label)
 {
@@ -344,7 +360,7 @@ bool buxton_direct_create_group(BuxtonControl *control,
 	_cleanup_buxton_data_ BuxtonData *group = NULL;
 	_cleanup_buxton_string_ BuxtonString *dlabel = NULL;
 	_cleanup_buxton_string_ BuxtonString *glabel = NULL;
-	bool r = false;
+	int32_t r = -1;
 
 	assert(control);
 	assert(key);
@@ -375,11 +391,13 @@ bool buxton_direct_create_group(BuxtonControl *control,
 		/* FIXME: should check client's capability set instead of UID */
 		if (control->client.uid != 0 && !skip_check) {
 			buxton_debug("Not permitted to create group '%s'\n", key->group.value);
+			r = EPERM;
 			goto fail;
 		}
 	}
 
-	if (buxton_direct_get_value_for_layer(control, key, group, glabel, NULL)) {
+	r = buxton_direct_get_value_for_layer(control, key, group, glabel, NULL);
+	if (r) {
 		buxton_debug("Group '%s' already exists\n", key->group.value);
 		goto fail;
 	}
@@ -421,7 +439,7 @@ fail:
 	return r;
 }
 
-bool buxton_direct_remove_group(BuxtonControl *control,
+int32_t buxton_direct_remove_group(BuxtonControl *control,
 				_BuxtonKey *key,
 				BuxtonString *client_label)
 {
@@ -430,7 +448,7 @@ bool buxton_direct_remove_group(BuxtonControl *control,
 	BuxtonConfig *config;
 	_cleanup_buxton_data_ BuxtonData *group = NULL;
 	_cleanup_buxton_string_ BuxtonString *glabel = NULL;
-	bool r = false;
+	int32_t ret = -1;
 
 	assert(control);
 	assert(key);
@@ -445,8 +463,11 @@ bool buxton_direct_remove_group(BuxtonControl *control,
 	config = &control->config;
 
 	if ((layer = hashmap_get(config->layers, key->layer.value)) == NULL) {
+		ret = ENOENT;
 		goto fail;
 	}
+
+
 
 	if (layer->type == LAYER_SYSTEM) {
 		char *root_check = getenv(BUXTON_ROOT_CHECK_ENV);
@@ -455,17 +476,20 @@ bool buxton_direct_remove_group(BuxtonControl *control,
 		/* FIXME: should check client's capability set instead of UID */
 		if (control->client.uid != 0 && !skip_check) {
 			buxton_debug("Not permitted to remove group '%s'\n", key->group.value);
+			ret = EPERM;
 			goto fail;
 		}
 	}
 
-	if (!buxton_direct_get_value_for_layer(control, key, group, glabel, NULL)) {
+	ret = buxton_direct_get_value_for_layer(control, key, group, glabel, NULL);
+	if (ret) {
 		buxton_debug("Group '%s' doesn't exist\n", key->group.value);
 		goto fail;
 	}
 
 	if (layer->type == LAYER_USER) {
 		if (client_label && !buxton_check_smack_access(client_label, glabel, ACCESS_WRITE)) {
+			ret = EPERM;
 			goto fail;
 		}
 	}
@@ -478,12 +502,12 @@ bool buxton_direct_remove_group(BuxtonControl *control,
 
 	layer->uid = control->client.uid;
 
-	r = backend->unset_value(layer, key, NULL, NULL);
-	if (!r)
+	ret = backend->unset_value(layer, key, NULL, NULL);
+	if (ret)
 		buxton_debug("remove group failed\n");
 
 fail:
-	return r;
+	return ret;
 }
 
 bool buxton_direct_list_keys(BuxtonControl *control,
@@ -547,7 +571,7 @@ bool buxton_direct_unset_value(BuxtonControl *control,
 	if (!buxton_copy_key_group(key, group))
 		goto fail;
 
-	if (!buxton_direct_get_value_for_layer(control, group, g, group_label, NULL)) {
+	if (buxton_direct_get_value_for_layer(control, group, g, group_label, NULL)) {
 		buxton_debug("Group %s for name %s missing for unset value\n", key->group.value, key->name.value);
 		goto fail;
 	}

--- a/src/shared/direct.h
+++ b/src/shared/direct.h
@@ -46,7 +46,7 @@ void buxton_direct_close(BuxtonControl *control);
  * @param label A BuxtonString containing the label to set
  * @return A boolean value, indicating success of the operation
  */
-bool buxton_direct_set_label(BuxtonControl *control,
+int32_t buxton_direct_set_label(BuxtonControl *control,
 			     _BuxtonKey *key,
 			     BuxtonString *label)
 	__attribute__((warn_unused_result));
@@ -58,7 +58,7 @@ bool buxton_direct_set_label(BuxtonControl *control,
  * @param label The Smack label of the client
  * @return A boolean value, indicating success of the operation
  */
-bool buxton_direct_create_group(BuxtonControl *control,
+int32_t buxton_direct_create_group(BuxtonControl *control,
 				_BuxtonKey *key,
 				BuxtonString *label)
 	__attribute__((warn_unused_result));
@@ -70,7 +70,7 @@ bool buxton_direct_create_group(BuxtonControl *control,
  * @param client_label The Smack label of the client
  * @return A boolean value, indicating success of the operation
  */
-bool buxton_direct_remove_group(BuxtonControl *control,
+int32_t buxton_direct_remove_group(BuxtonControl *control,
 				_BuxtonKey *key,
 				BuxtonString *client_label)
 	__attribute__((warn_unused_result));
@@ -83,7 +83,7 @@ bool buxton_direct_remove_group(BuxtonControl *control,
  * @param label The Smack label for the client
  * @return A boolean value, indicating success of the operation
  */
-bool buxton_direct_set_value(BuxtonControl *control,
+int32_t buxton_direct_set_value(BuxtonControl *control,
 			     _BuxtonKey *key,
 			     BuxtonData *data,
 			     BuxtonString *label)
@@ -98,7 +98,7 @@ bool buxton_direct_set_value(BuxtonControl *control,
  * @param client_label The Smack label of the client
  * @return A boolean value, indicating success of the operation
  */
-bool buxton_direct_get_value(BuxtonControl *control,
+int32_t buxton_direct_get_value(BuxtonControl *control,
 			     _BuxtonKey *key,
 			     BuxtonData *data,
 			     BuxtonString *data_label,
@@ -114,7 +114,7 @@ bool buxton_direct_get_value(BuxtonControl *control,
  * @param client_label The Smack label of the client
  * @return A boolean value, indicating success of the operation
  */
-bool buxton_direct_get_value_for_layer(BuxtonControl *control,
+int32_t buxton_direct_get_value_for_layer(BuxtonControl *control,
 				       _BuxtonKey *key,
 				       BuxtonData *data,
 				       BuxtonString *data_label,

--- a/src/shared/protocol.c
+++ b/src/shared/protocol.c
@@ -165,7 +165,7 @@ bool send_message(_BuxtonClient *client, uint8_t *send, size_t send_len,
 	s = hashmap_put(callbacks, (void *)msgid, nv);
 	(void)pthread_mutex_unlock(&callback_guard);
 
-	if (s < 1) {
+	if (s) {
 		buxton_debug("Error adding callback for msgid: %llu\n", msgid);
 		goto fail;
 	}
@@ -208,13 +208,12 @@ void handle_callback_response(BuxtonControlMessage msg, uint64_t msgid,
 
 	if (nv->type == BUXTON_CONTROL_NOTIFY) {
 		if (list[0].type == INT32 &&
-		    list[0].store.d_int32 == BUXTON_STATUS_OK)
-			if (hashmap_put(notify_callbacks, (void *)msgid, nv)
-			    >= 0)
+		    list[0].store.d_int32 == 0)
+			if (hashmap_put(notify_callbacks, (void *)msgid, nv) >= 0)
 				return;
 	} else if (nv->type == BUXTON_CONTROL_UNNOTIFY) {
 		if (list[0].type == INT32 &&
-		    list[0].store.d_int32 == BUXTON_STATUS_OK) {
+		    list[0].store.d_int32 == 0) {
 			(void)hashmap_remove(notify_callbacks,
 					     (void *)list[2].store.d_uint64);
 			return;

--- a/test/check_buxton.c
+++ b/test/check_buxton.c
@@ -53,7 +53,7 @@ START_TEST(buxton_direct_create_group_check)
 	group.group = buxton_string_pack("tgroup");
 	group.name = (BuxtonString){ NULL, 0 };
 	group.type = STRING;
-	fail_if(!buxton_direct_create_group(&c, &group, NULL),
+	fail_if(buxton_direct_create_group(&c, &group, NULL),
 		"Create group failed");
 }
 END_TEST
@@ -69,7 +69,7 @@ START_TEST(buxton_direct_remove_group_check)
 	group.group = buxton_string_pack("tgroup");
 	group.name = (BuxtonString){ NULL, 0 };
 	group.type = STRING;
-	fail_if(!buxton_direct_remove_group(&c, &group, NULL),
+	fail_if(buxton_direct_remove_group(&c, &group, NULL),
 		"Failed to remove group");
 }
 END_TEST
@@ -96,13 +96,13 @@ START_TEST(buxton_direct_set_value_check)
 	key.type = STRING;
 
 	c.client.uid = getuid();
-	fail_if(buxton_direct_create_group(&c, &group, NULL) == false,
+	fail_if(buxton_direct_create_group(&c, &group, NULL) != 0,
 		"Creating group failed.");
-	fail_if(buxton_direct_set_label(&c, &group, &glabel) == false,
+	fail_if(buxton_direct_set_label(&c, &group, &glabel) != 0,
 		"Setting group label failed.");
 	data.type = STRING;
 	data.store.d_string = buxton_string_pack("bxt_test_value");
-	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) == false,
+	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) != 0,
 		"Setting value in buxton directly failed.");
 	buxton_direct_close(&c);
 }
@@ -123,7 +123,7 @@ START_TEST(buxton_direct_get_value_for_layer_check)
 	c.client.uid = getuid();
 	fail_if(buxton_direct_open(&c) == false,
 		"Direct open failed without daemon.");
-	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) == false,
+	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) != 0,
 		"Retrieving value from buxton gdbm backend failed.");
 	fail_if(result.type != STRING,
 		"Buxton gdbm backend returned incorrect result type.");
@@ -155,9 +155,9 @@ START_TEST(buxton_direct_get_value_check)
 	data.store.d_string = buxton_string_pack("bxt_test_value2");
 	fail_if(data.store.d_string.value == NULL,
 		"Failed to allocate test string.");
-	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) == false,
+	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) != 0,
 		"Failed to set second value.");
-	fail_if(buxton_direct_get_value(&c, &key, &result, &dlabel, NULL) == false,
+	fail_if(buxton_direct_get_value(&c, &key, &result, &dlabel, NULL) != 0,
 		"Retrieving value from buxton gdbm backend failed.");
 	fail_if(result.type != STRING,
 		"Buxton gdbm backend returned incorrect result type.");
@@ -193,15 +193,15 @@ START_TEST(buxton_memory_backend_check)
 		"Direct open failed without daemon.");
 
 	c.client.uid = getuid();
-	fail_if(buxton_direct_create_group(&c, &group, NULL) == false,
+	fail_if(buxton_direct_create_group(&c, &group, NULL) != 0,
 		"Creating group failed.");
-	fail_if(buxton_direct_set_label(&c, &group, &glabel) == false,
+	fail_if(buxton_direct_set_label(&c, &group, &glabel) != 0,
 		"Setting group label failed.");
 	data.type = STRING;
 	data.store.d_string = buxton_string_pack("bxt_test_value");
-	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) == false,
+	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) != 0,
 		"Setting value in buxton memory backend directly failed.");
-	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) == false,
+	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) != 0,
 		"Retrieving value from buxton memory backend directly failed.");
 	// FIXME: BUXTON_GROUP_VALUE is the dummy group data value, but the memory
 	// backend doesn't understand groups, so this is the current workaround.
@@ -273,9 +273,9 @@ START_TEST(buxton_set_label_check)
 	c.client.uid = 0;
 	fail_if(buxton_direct_open(&c) == false,
 		"Direct open failed without daemon.");
-	fail_if(buxton_direct_create_group(&c, &key, NULL) == false,
+	fail_if(buxton_direct_create_group(&c, &key, NULL) != 0,
 		"Creating group failed.");
-	fail_if(buxton_direct_set_label(&c, &key, &label) == false,
+	fail_if(buxton_direct_set_label(&c, &key, &label) != 0,
 		"Failed to set label as root user.");
 
 	c.client.uid = 1000;
@@ -307,11 +307,11 @@ START_TEST(buxton_group_label_check)
 	c.client.uid = 0;
 	fail_if(buxton_direct_open(&c) == false,
 		"Direct open failed without daemon.");
-	fail_if(buxton_direct_create_group(&c, &key, NULL) == false,
+	fail_if(buxton_direct_create_group(&c, &key, NULL) != 0,
 		"Creating group failed.");
-	fail_if(buxton_direct_set_label(&c, &key, &label) == false,
+	fail_if(buxton_direct_set_label(&c, &key, &label) != 0,
 		"Failed to set group label.");
-	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) == false,
+	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) != 0,
 		"Retrieving group label failed.");
 	fail_if(!streq("*", dlabel.value),
 		"Retrieved group label is incorrect.");
@@ -338,11 +338,11 @@ START_TEST(buxton_name_label_check)
 	c.client.uid = 0;
 	fail_if(buxton_direct_open(&c) == false,
 		"Direct open failed without daemon.");
-	fail_if(buxton_direct_create_group(&c, &key, NULL) == false,
+	fail_if(buxton_direct_create_group(&c, &key, NULL) != 0,
 		"Creating group failed.");
-	fail_if(buxton_direct_set_label(&c, &key, &label) == false,
+	fail_if(buxton_direct_set_label(&c, &key, &label) != 0,
 		"Failed to set group label.");
-	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) == false,
+	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) != 0,
 		"Retrieving group label failed.");
 	fail_if(!streq("*", dlabel.value),
 		"Retrieved group label is incorrect.");
@@ -353,18 +353,18 @@ START_TEST(buxton_name_label_check)
 	key.name = buxton_string_pack("name-foo");
 	data.type = STRING;
 	data.store.d_string = buxton_string_pack("value1-foo");
-	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) == false,
+	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) != 0,
 		"Failed to set key name-foo.");
-	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) == false,
+	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) != 0,
 		"Failed to get value for name-foo 1");
 	fail_if(!streq("value1-foo", result.store.d_string.value),
 		"Retrieved key value is incorrect 1");
 	fail_if(!streq(dlabel.value, "_"), "Failed to set default label");
 	free(dlabel.value);
 	free(result.store.d_string.value);
-	fail_if(buxton_direct_set_label(&c, &key, &label) == false,
+	fail_if(buxton_direct_set_label(&c, &key, &label) != 0,
 		"Failed to set name label.");
-	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) == false,
+	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) != 0,
 		"Failed to get value for name-foo 2");
 	fail_if(!streq("value1-foo", result.store.d_string.value),
 		"Retrieved key value is incorrect 2");
@@ -375,9 +375,9 @@ START_TEST(buxton_name_label_check)
 
 	/* modify the same key, with a new value, and validate the label */
 	data.store.d_string = buxton_string_pack("value2-foo");
-	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) == false,
+	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) != 0,
 		"Failed to modify key name-foo.");
-	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) == false,
+	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) != 0,
 		"Failed to get new value for name-foo.");
 	fail_if(!streq("value2-foo", result.store.d_string.value),
 		"New key value is incorrect.");
@@ -385,7 +385,7 @@ START_TEST(buxton_name_label_check)
 		"Key label has been modified.");
 
 	/* modify the key label directly once it has been created */
-	fail_if(buxton_direct_set_label(&c, &key, &label) == false,
+	fail_if(buxton_direct_set_label(&c, &key, &label) != 0,
 		"Failed to modify label on key.");
 
 	free(dlabel.value);

--- a/test/check_daemon.c
+++ b/test/check_daemon.c
@@ -182,7 +182,7 @@ static void client_create_group_test(BuxtonResponse response, void *data)
 		"Failed to get create group response type");
 
 	if (uid == 0) {
-		fail_if(response_status(response) != BUXTON_STATUS_OK,
+		fail_if(response_status(response) != 0,
 			"Create group failed");
 		key = response_key(response);
 		fail_if(!key, "Failed to get create group key");
@@ -193,7 +193,7 @@ static void client_create_group_test(BuxtonResponse response, void *data)
 		free(group);
 		buxton_free_key(key);
 	} else {
-		fail_if(response_status(response) != BUXTON_STATUS_FAILED  && !skip_check,
+		fail_if(response_status(response) == 0  && !skip_check,
 			"Create group succeeded, but the client is not root");
 	}
 }
@@ -224,7 +224,7 @@ static void client_remove_group_test(BuxtonResponse response, void *data)
 		"Failed to get remove group response type");
 
 	if (uid == 0) {
-		fail_if(response_status(response) != BUXTON_STATUS_OK,
+		fail_if(response_status(response) != 0,
 			"Remove group failed");
 		key = response_key(response);
 		fail_if(!key, "Failed to get create group key");
@@ -235,7 +235,7 @@ static void client_remove_group_test(BuxtonResponse response, void *data)
 		free(group);
 		buxton_free_key(key);
 	} else {
-		fail_if(response_status(response) != BUXTON_STATUS_FAILED  && !skip_check,
+		fail_if(response_status(response) == 0  && !skip_check,
 			"Create group succeeded, but the client is not root");
 	}
 }
@@ -261,7 +261,7 @@ static void client_set_value_test(BuxtonResponse response, void *data)
 
 	fail_if(response_type(response) != BUXTON_CONTROL_SET,
 		"Failed to get set response type");
-	fail_if(response_status(response) != BUXTON_STATUS_OK,
+	fail_if(response_status(response) != 0,
 		"Set value failed");
 	key = response_key(response);
 	fail_if(!key, "Failed to get set key");
@@ -308,7 +308,7 @@ static void client_set_label_test(BuxtonResponse response, void *data)
 		"Failed to get set label response type");
 
 	if (uid == 0) {
-		fail_if(response_status(response) != BUXTON_STATUS_OK,
+		fail_if(response_status(response) != 0,
 			"Set label failed");
 		key = response_key(response);
 		fail_if(!key, "Failed to get set label key");
@@ -333,10 +333,10 @@ static void client_set_label_test(BuxtonResponse response, void *data)
 		buxton_free_key(key);
 	} else {
 		if (skip_check) {
-			fail_if(response_status(response) != BUXTON_STATUS_OK,
+			fail_if(response_status(response) != 0,
 			"Set label failed");
 		} else {
-			fail_if(response_status(response) != BUXTON_STATUS_FAILED,
+			fail_if(response_status(response) == 0,
 			"Set label succeeded, but the client is not root");
 		}
 	}
@@ -377,7 +377,7 @@ static void client_get_value_test(BuxtonResponse response, void *data)
 	char *v;
 	char *value = (char *)data;
 
-	fail_if(response_status(response) != BUXTON_STATUS_OK,
+	fail_if(response_status(response) != 0,
 		"Get value failed");
 
 	key = response_key(response);
@@ -740,7 +740,7 @@ START_TEST(create_group_check)
 {
 	_BuxtonKey key = { {0}, {0}, {0}, 0};
 	client_list_item client;
-	BuxtonStatus status;
+	int32_t status;
 	BuxtonDaemon server;
 	BuxtonString clabel = buxton_string_pack("_");
 
@@ -758,16 +758,16 @@ START_TEST(create_group_check)
 	key.group = buxton_string_pack("daemon-check");
 	key.type = STRING;
 	create_group(&server, &client, &key, &status);
-	fail_if(status != BUXTON_STATUS_OK, "Failed to create group");
+	fail_if(status != 0, "Failed to create group");
 
 	key.layer = buxton_string_pack("test-gdbm");
 	create_group(&server, &client, &key, &status);
-	fail_if(status != BUXTON_STATUS_OK, "Failed to create group");
+	fail_if(status != 0, "Failed to create group");
 
 	key.layer = buxton_string_pack("base");
 	key.group = buxton_string_pack("tgroup");
 	create_group(&server, &client, &key, &status);
-	fail_if(status != BUXTON_STATUS_OK, "Failed to create group");
+	fail_if(status != 0, "Failed to create group");
 
 	buxton_direct_close(&server.buxton);
 }
@@ -777,7 +777,7 @@ START_TEST(remove_group_check)
 {
 	_BuxtonKey key = { {0}, {0}, {0}, 0};
 	client_list_item client;
-	BuxtonStatus status;
+	int32_t status;
 	BuxtonDaemon server;
 	BuxtonString clabel = buxton_string_pack("_");
 
@@ -796,7 +796,7 @@ START_TEST(remove_group_check)
 	key.type = STRING;
 
 	remove_group(&server, &client, &key, &status);
-	fail_if(status != BUXTON_STATUS_OK, "Failed to remove group");
+	fail_if(status != 0, "Failed to remove group");
 
 	buxton_direct_close(&server.buxton);
 }
@@ -807,7 +807,7 @@ START_TEST(set_label_check)
 	_BuxtonKey key = { {0}, {0}, {0}, 0};
 	BuxtonData value;
 	client_list_item client;
-	BuxtonStatus status;
+	int32_t status;
 	BuxtonDaemon server;
 	BuxtonString clabel = buxton_string_pack("_");
 
@@ -828,7 +828,7 @@ START_TEST(set_label_check)
 
 	key.layer = buxton_string_pack("test-gdbm");
 	set_label(&server, &client, &key, &value, &status);
-	fail_if(status != BUXTON_STATUS_OK, "Failed to set label 2");
+	fail_if(status != 0, "Failed to set label 2");
 	buxton_direct_close(&server.buxton);
 }
 END_TEST
@@ -838,7 +838,7 @@ START_TEST(set_value_check)
 	_BuxtonKey key = { {0}, {0}, {0}, 0};
 	BuxtonData value;
 	client_list_item client;
-	BuxtonStatus status;
+	int32_t status;
 	BuxtonDaemon server;
 	BuxtonString clabel = buxton_string_pack("_");
 
@@ -860,13 +860,13 @@ START_TEST(set_value_check)
 	value.store.d_string = buxton_string_pack("user-layer-value");
 
 	set_value(&server, &client, &key, &value, &status);
-	fail_if(status != BUXTON_STATUS_OK, "Failed to set value");
+	fail_if(status != 0, "Failed to set value");
 	fail_if(server.buxton.client.uid != client.cred.uid, "Failed to change buxton uid");
 
 	key.layer = buxton_string_pack("test-gdbm");
 	value.store.d_string = buxton_string_pack("system-layer-value");
 	set_value(&server, &client, &key, &value, &status);
-	fail_if(status != BUXTON_STATUS_OK, "Failed to set value");
+	fail_if(status != 0, "Failed to set value");
 
 	buxton_direct_close(&server.buxton);
 }
@@ -877,7 +877,7 @@ START_TEST(get_value_check)
 	_BuxtonKey key = { {0}, {0}, {0}, 0};
 	BuxtonData *value;
 	client_list_item client;
-	BuxtonStatus status;
+	int32_t status;
 	BuxtonDaemon server;
 	BuxtonString clabel = buxton_string_pack("_");
 
@@ -899,7 +899,7 @@ START_TEST(get_value_check)
 
 	value = get_value(&server, &client, &key, &status);
 	fail_if(!value, "Failed to get value");
-	fail_if(status != BUXTON_STATUS_OK, "Failed to get value");
+	fail_if(status != 0, "Failed to get value");
 	fail_if(value->type != STRING, "Failed to get correct type");
 	fail_if(!streq(value->store.d_string.value, "user-layer-value"), "Failed to get correct value");
 	fail_if(server.buxton.client.uid != client.cred.uid, "Failed to change buxton uid");
@@ -910,7 +910,7 @@ START_TEST(get_value_check)
 	key.layer.length = 0;
 	value = get_value(&server, &client, &key, &status);
 	fail_if(!value, "Failed to get value 2");
-	fail_if(status != BUXTON_STATUS_OK, "Failed to get value 2");
+	fail_if(status != 0, "Failed to get value 2");
 	fail_if(value->type != STRING, "Failed to get correct type 2");
 	fail_if(!streq(value->store.d_string.value, "system-layer-value"), "Failed to get correct value 2");
 	fail_if(server.buxton.client.uid != client.cred.uid, "Failed to change buxton uid 2");
@@ -925,7 +925,7 @@ START_TEST(register_notification_check)
 	_BuxtonKey key = { {0}, {0}, {0}, 0};
 	client_list_item client, no_client;
 	BuxtonString clabel = buxton_string_pack("_");
-	BuxtonStatus status;
+	int32_t status;
 	BuxtonDaemon server;
 	uint64_t msgid;
 
@@ -945,27 +945,27 @@ START_TEST(register_notification_check)
 	key.name = buxton_string_pack("name");
 	key.type = STRING;
 	register_notification(&server, &client, &key, 1, &status);
-	fail_if(status != BUXTON_STATUS_OK, "Failed to register notification");
+	fail_if(status != 0, "Failed to register notification");
 	register_notification(&server, &client, &key, 1, &status);
-	fail_if(status != BUXTON_STATUS_OK, "Failed to register notification");
+	fail_if(status != 0, "Failed to register notification");
 	//FIXME: Figure out what to do with duplicates
 	key.group = buxton_string_pack("no-key");
 	msgid = unregister_notification(&server, &client, &key, &status);
-	fail_if(status != BUXTON_STATUS_FAILED,
+	fail_if(status == 0,
 		"Unregistered from notifications with invalid key");
 	fail_if(msgid != 0, "Got unexpected notify message id");
 	key.group = buxton_string_pack("group");
 	msgid = unregister_notification(&server, &no_client, &key, &status);
-	fail_if(status != BUXTON_STATUS_FAILED,
+	fail_if(status == 0,
 		"Unregistered from notifications with invalid client");
 	fail_if(msgid != 0, "Got unexpected notify message id");
 	msgid = unregister_notification(&server, &client, &key, &status);
-	fail_if(status != BUXTON_STATUS_OK,
+	fail_if(status != 0,
 		"Unable to unregister from notifications");
 	fail_if(msgid != 1, "Failed to get correct notify message id");
 	key.group = buxton_string_pack("key2");
 	register_notification(&server, &client, &key, 0, &status);
-	fail_if(status == BUXTON_STATUS_OK, "Registered notification with key not in db");
+	fail_if(status == 0, "Registered notification with key not in db");
 
 	hashmap_free(server.notify_mapping);
 	buxton_direct_close(&server.buxton);
@@ -1096,7 +1096,7 @@ START_TEST(bt_daemon_handle_message_create_group_check)
 		"Failed to get correct control type");
 	fail_if(list[0].type != INT32,
 		"Failed to get correct indicator type");
-	fail_if(list[0].store.d_int32 != BUXTON_STATUS_OK,
+	fail_if(list[0].store.d_int32 != 0,
 		"Failed to create group");
 	fail_if(msgid != 0, "Failed to get correct message id");
 	free(list);
@@ -1125,7 +1125,7 @@ START_TEST(bt_daemon_handle_message_create_group_check)
 		"Failed to get correct control type");
 	fail_if(list[0].type != INT32,
 		"Failed to get correct indicator type");
-	fail_if(list[0].store.d_int32 != BUXTON_STATUS_OK,
+	fail_if(list[0].store.d_int32 != 0,
 		"Failed to create group");
 	fail_if(msgid != 1, "Failed to get correct message id");
 
@@ -1202,7 +1202,7 @@ START_TEST(bt_daemon_handle_message_remove_group_check)
 		"Failed to get correct control type");
 	fail_if(list[0].type != INT32,
 		"Failed to get correct indicator type");
-	fail_if(list[0].store.d_int32 != BUXTON_STATUS_OK,
+	fail_if(list[0].store.d_int32 != 0,
 		"Failed to remove group");
 	fail_if(msgid != 0, "Failed to get correct message id");
 
@@ -1282,7 +1282,7 @@ START_TEST(bt_daemon_handle_message_set_label_check)
 		"Failed to get correct control type");
 	fail_if(list[0].type != INT32,
 		"Failed to get correct indicator type");
-	fail_if(list[0].store.d_int32 != BUXTON_STATUS_OK,
+	fail_if(list[0].store.d_int32 != 0,
 		"Failed to set label");
 	fail_if(msgid != 0, "Failed to get correct message id");
 
@@ -1372,7 +1372,7 @@ START_TEST(bt_daemon_handle_message_set_value_check)
 		"Failed to get correct control type");
 	fail_if(list[0].type != INT32,
 		"Failed to get correct indicator type");
-	fail_if(list[0].store.d_int32 != BUXTON_STATUS_OK,
+	fail_if(list[0].store.d_int32 != 0,
 		"Failed to set");
 	fail_if(msgid != 0, "Failed to get correct message id");
 
@@ -1450,7 +1450,7 @@ START_TEST(bt_daemon_handle_message_get_check)
 		"Failed to get correct control type");
 	fail_if(msgid != 0, "Failed to get correct message id");
 	fail_if(list[0].type != INT32, "Failed to get correct response type");
-	fail_if(list[0].store.d_int32 != BUXTON_STATUS_OK,
+	fail_if(list[0].store.d_int32 != 0,
 		"Failed to get value");
 	fail_if(list[1].type != STRING, "Failed to get correct value type");
 	fail_if(!streq(list[1].store.d_string.value, "user-layer-value"),
@@ -1482,7 +1482,7 @@ START_TEST(bt_daemon_handle_message_get_check)
 		"Failed to get correct control type 2");
 	fail_if(msgid != 0, "Failed to get correct message id 2");
 	fail_if(list[0].type != INT32, "Failed to get correct response type 2");
-	fail_if(list[0].store.d_int32 != BUXTON_STATUS_OK,
+	fail_if(list[0].store.d_int32 != 0,
 		"Failed to get value 2");
 	fail_if(list[1].type != STRING, "Failed to get correct value type 2");
 	fail_if(streq(list[1].store.d_string.value, "bxt_test_value2"),
@@ -1559,7 +1559,7 @@ START_TEST(bt_daemon_handle_message_notify_check)
 		"Failed to get correct control type");
 	fail_if(msgid != 0, "Failed to get correct notify message id");
 	fail_if(list[0].type != INT32, "Failed to get correct response type");
-	fail_if(list[0].store.d_int32 != BUXTON_STATUS_OK,
+	fail_if(list[0].store.d_int32 != 0,
 		"Failed to register notification");
 
 	free(list);
@@ -1580,7 +1580,7 @@ START_TEST(bt_daemon_handle_message_notify_check)
 		"Failed to get correct control type 2");
 	fail_if(list[0].type != INT32,
 		"Failed to get correct indicator type 2");
-	fail_if(list[0].store.d_int32 != BUXTON_STATUS_OK,
+	fail_if(list[0].store.d_int32 != 0,
 		"Failed to unregister for notification");
 	fail_if(list[1].type != UINT64,
 		"Failed to get correct unnotify message id type");
@@ -1662,7 +1662,7 @@ START_TEST(bt_daemon_handle_message_unset_check)
 		"Failed to get correct control type");
 	fail_if(list[0].type != INT32,
 		"Failed to get correct indicator type");
-	fail_if(list[0].store.d_int32 != BUXTON_STATUS_OK,
+	fail_if(list[0].store.d_int32 != 0,
 		"Failed to unset");
 	fail_if(msgid != 0, "Failed to get correct message id");
 
@@ -1682,7 +1682,7 @@ START_TEST(bt_daemon_notify_clients_check)
 	BuxtonString slabel;
 	BuxtonData value1, value2;
 	client_list_item cl;
-	BuxtonStatus status;
+	int32_t status;
 	bool r;
 	BuxtonData *list;
 	BuxtonControlMessage msg;
@@ -1722,7 +1722,7 @@ START_TEST(bt_daemon_notify_clients_check)
 				    &value1, NULL);
 	fail_if(!r, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
-	fail_if(status != BUXTON_STATUS_OK,
+	fail_if(status != 0,
 		"Failed to register notification for notify");
 	bt_daemon_notify_clients(&daemon, &cl, &key, &value1);
 
@@ -1765,7 +1765,7 @@ START_TEST(bt_daemon_notify_clients_check)
 				    &value1, NULL);
 	fail_if(!r, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
-	fail_if(status != BUXTON_STATUS_OK,
+	fail_if(status != 0,
 		"Failed to register notification for notify");
 	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
 
@@ -1795,7 +1795,7 @@ START_TEST(bt_daemon_notify_clients_check)
 				    &value1, NULL);
 	fail_if(!r, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
-	fail_if(status != BUXTON_STATUS_OK,
+	fail_if(status != 0,
 		"Failed to register notification for notify");
 	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
 
@@ -1825,7 +1825,7 @@ START_TEST(bt_daemon_notify_clients_check)
 				    &value1, NULL);
 	fail_if(!r, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
-	fail_if(status != BUXTON_STATUS_OK,
+	fail_if(status != 0,
 		"Failed to register notification for notify");
 	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
 
@@ -1855,7 +1855,7 @@ START_TEST(bt_daemon_notify_clients_check)
 				    &value1, NULL);
 	fail_if(!r, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
-	fail_if(status != BUXTON_STATUS_OK,
+	fail_if(status != 0,
 		"Failed to register notification for notify");
 	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
 
@@ -1885,7 +1885,7 @@ START_TEST(bt_daemon_notify_clients_check)
 				    &value1, NULL);
 	fail_if(!r, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
-	fail_if(status != BUXTON_STATUS_OK,
+	fail_if(status != 0,
 		"Failed to register notification for notify");
 	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
 
@@ -1915,7 +1915,7 @@ START_TEST(bt_daemon_notify_clients_check)
 				    &value1, NULL);
 	fail_if(!r, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
-	fail_if(status != BUXTON_STATUS_OK,
+	fail_if(status != 0,
 		"Failed to register notification for notify");
 	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
 
@@ -1945,7 +1945,7 @@ START_TEST(bt_daemon_notify_clients_check)
 				    &value1, NULL);
 	fail_if(!r, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
-	fail_if(status != BUXTON_STATUS_OK,
+	fail_if(status != 0,
 		"Failed to register notification for notify");
 	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
 


### PR DESCRIPTION
Adds error reporting from server to client via the callback and
response. Use

in32_t response_status(BuxtonResponse response)

to obtain the error code, then use standard errno.h

Signed off by Brad Peters brad.t.peters@intel.com
