### PR TITLE
daemon: rename bt-daemon to buxtond

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ m4/*.m4
 *.trs
 /cscope.*
 /tags
-bt-daemon
+buxtond
 buxtonctl
 check_buxton
 data/buxton.service
@@ -37,7 +37,7 @@ log-check-stderr-file
 test/*.ini
 src/shared/constants.c
 check_daemon
-check_bt_daemon
+check_buxtond
 check_smack
 bxt_timing
 bxt_gtk_client

--- a/Makefile.am
+++ b/Makefile.am
@@ -86,21 +86,21 @@ dist_sysconf_DATA = \
 	data/buxton.conf
 
 sbin_PROGRAMS = \
-	bt-daemon
+	buxtond
 
 bin_PROGRAMS = \
 	buxtonctl
 
-bt_daemon_SOURCES = \
+buxtond_SOURCES = \
 	src/core/daemon.c \
 	src/core/daemon.h \
 	src/core/main.c
 
-bt_daemon_LDADD = \
+buxtond_LDADD = \
 	$(SYSTEMD_LIBS) \
 	libbuxton-shared.la
 
-bt_daemon_CFLAGS = \
+buxtond_CFLAGS = \
 	$(AM_CFLAGS)
 
 buxtonctl_SOURCES = \
@@ -214,7 +214,7 @@ memory_la_LDFLAGS = \
 check_PROGRAMS = \
 	check_buxton \
 	check_shared_lib \
-	check_bt_daemon \
+	check_buxtond \
 	check_daemon \
 	check_smack \
 	check_configurator
@@ -251,20 +251,20 @@ check_shared_lib_LDADD = \
 	libbuxton.la \
 	libbuxton-shared.la
 
-check_bt_daemon_SOURCES = \
+check_buxtond_SOURCES = \
 	test/check_utils.c \
 	test/check_utils.h \
 	src/core/daemon.c \
 	src/core/daemon.h \
 	src/core/main.c
-check_bt_daemon_CFLAGS = \
+check_buxtond_CFLAGS = \
 	@CHECK_CFLAGS@ \
 	$(AM_CFLAGS) \
 	@INIPARSER_CFLAGS@ \
 	-DMAKE_CHECK \
 	-DABS_TOP_SRCDIR=\"$(abs_top_srcdir)\" \
 	-DABS_TOP_BUILDDIR=\"$(abs_top_builddir)\"
-check_bt_daemon_LDADD = \
+check_buxtond_LDADD = \
 	@CHECK_LIBS@ \
 	$(SYSTEMD_LIBS) \
 	libbuxton.la \

--- a/README
+++ b/README
@@ -8,7 +8,7 @@ Mandatory Access Control (MAC) is implemented at the group level and at the
 key-value level.
 
 Buxton provides a C library (libbuxton) for client applications to use.
-Internally, buxton uses a daemon (bt-daemon) for processing client requests and
+Internally, buxton uses a daemon (buxtond) for processing client requests and
 enforcing MAC. Also, a CLI (buxtonctl) is provided for interactive use and for
 use in shell scripts.
 
@@ -25,7 +25,7 @@ Build dependencies
 - Linux kernel headers, for the inotify header
 
 - systemd, for autodetection of service file locations, for socket activation
-  of bt-daemon, and the initialization of the Smack virtual filesystem
+  of buxtond, and the initialization of the Smack virtual filesystem
 
 
 Additional runtime dependencies

--- a/TODO
+++ b/TODO
@@ -13,7 +13,7 @@ Status: In progress. Refer to https://github.com/sofar/buxton/wiki/Smack-TODO
         for details.
 
 Description: Test multi-part messaging in the client-side of the library,
-	     mirroring changes made to bt-daemon's protocol handling
+	     mirroring changes made to buxtond's protocol handling
 Difficulty: Complex
 Time to complete: ??
 Target: ??

--- a/data/buxton.service.in
+++ b/data/buxton.service.in
@@ -2,7 +2,7 @@
 Description=Buxton Configuration Service
 
 [Service]
-ExecStart=@prefix@/sbin/bt-daemon
+ExecStart=@prefix@/sbin/buxtond
 User=@BUXTON_USERNAME@
 
 [Install]

--- a/src/core/daemon.c
+++ b/src/core/daemon.c
@@ -147,7 +147,7 @@ bool parse_list(BuxtonControlMessage msg, size_t count, BuxtonData *list,
 	return true;
 }
 
-bool bt_daemon_handle_message(BuxtonDaemon *self, client_list_item *client, size_t size)
+bool buxtond_handle_message(BuxtonDaemon *self, client_list_item *client, size_t size)
 {
 	BuxtonControlMessage msg;
 	BuxtonStatus response;
@@ -185,7 +185,7 @@ bool bt_daemon_handle_message(BuxtonDaemon *self, client_list_item *client, size
 	if (!parse_list(msg, p_count, list, &key, &value))
 		goto end;
 
-	/* use internal function from bt-daemon */
+	/* use internal function from buxtond */
 	switch (msg) {
 	case BUXTON_CONTROL_SET:
 		set_value(self, client, &key, value, &response);
@@ -336,9 +336,9 @@ bool bt_daemon_handle_message(BuxtonDaemon *self, client_list_item *client, size
 	ret = _write(client->fd, response_store, response_len);
 	if (ret) {
 		if (msg == BUXTON_CONTROL_SET && response == BUXTON_STATUS_OK)
-			bt_daemon_notify_clients(self, client, &key, value);
+			buxtond_notify_clients(self, client, &key, value);
 		else if (msg == BUXTON_CONTROL_UNSET && response == BUXTON_STATUS_OK)
-			bt_daemon_notify_clients(self, client, &key, NULL);
+			buxtond_notify_clients(self, client, &key, NULL);
 	}
 
 end:
@@ -354,7 +354,7 @@ end:
 	return ret;
 }
 
-void bt_daemon_notify_clients(BuxtonDaemon *self, client_list_item *client,
+void buxtond_notify_clients(BuxtonDaemon *self, client_list_item *client,
 			      _BuxtonKey *key, BuxtonData *value)
 {
 	BuxtonList *list = NULL;
@@ -956,7 +956,7 @@ bool handle_client(BuxtonDaemon *self, client_list_item *cl, nfds_t i)
 		}
 		if (cl->size != cl->offset)
 			continue;
-		if (!bt_daemon_handle_message(self, cl, cl->size)) {
+		if (!buxtond_handle_message(self, cl, cl->size)) {
 			buxton_log("Communication failed with client %d\n", cl->fd);
 			goto terminate;
 		}

--- a/src/core/daemon.h
+++ b/src/core/daemon.h
@@ -12,7 +12,7 @@
 /**
  * \file daemon.h Internal header
  * This file is used internally by buxton to provide functionality
- * used for the bt-daemon
+ * used for the buxtond
  */
 #pragma once
 
@@ -53,7 +53,7 @@ typedef struct BuxtonNotification {
 } BuxtonNotification;
 
 /**
- * Global store of bt-daemon state
+ * Global store of buxtond state
  */
 typedef struct BuxtonDaemon {
 	size_t nfds_alloc;
@@ -81,30 +81,30 @@ bool parse_list(BuxtonControlMessage msg, size_t count, BuxtonData *list,
 	__attribute__((warn_unused_result));
 
 /**
- * Handle a message within bt-daemon
+ * Handle a message within buxtond
  * @param self Reference to BuxtonDaemon
  * @param client Current client
  * @param size Size of the data being handled
  * @returns bool True if message was successfully handled
  */
-bool bt_daemon_handle_message(BuxtonDaemon *self,
+bool buxtond_handle_message(BuxtonDaemon *self,
 			      client_list_item *client,
 			      size_t size)
 	__attribute__((warn_unused_result));
 
 /**
- * Notify clients a value changes in bt-daemon
+ * Notify clients a value changes in buxtond
  * @param self Refernece to BuxtonDaemon
  * @param client Current client
  * @param key Modified key
  * @param value Modified value
  */
-void bt_daemon_notify_clients(BuxtonDaemon *self, client_list_item *client,
+void buxtond_notify_clients(BuxtonDaemon *self, client_list_item *client,
 			      _BuxtonKey* key, BuxtonData *value);
 
 /**
  * Buxton daemon function for setting a value
- * @param self bt-daemon instance being run
+ * @param self buxtond instance being run
  * @param client Used to validate smack access
  * @param key Key for the value being set
  * @param value Value being set
@@ -115,7 +115,7 @@ void set_value(BuxtonDaemon *self, client_list_item *client,
 
 /**
  * Buxton daemon function for setting a label
- * @param self bt-daemon instance being run
+ * @param self buxtond instance being run
  * @param client Used to validate smack access
  * @param key Key or group for the label being set
  * @param value Label being set
@@ -126,7 +126,7 @@ void set_label(BuxtonDaemon *self, client_list_item *client,
 
 /**
  * Buxton daemon function for creating a group
- * @param self bt-daemon instance being run
+ * @param self buxtond instance being run
  * @param client Used to validate smack access
  * @param key Key with layer and group members initialized
  * @param status Will be set with the BuxtonStatus result of the operation
@@ -136,7 +136,7 @@ void create_group(BuxtonDaemon *self, client_list_item *client,
 
 /**
  * Buxton daemon function for removing a group
- * @param self bt-daemon instance being run
+ * @param self buxtond instance being run
  * @param client Used to validate smack access
  * @param key Key with layer and group members initialized
  * @param status Will be set with the BuxtonStatus result of the operation
@@ -146,7 +146,7 @@ void remove_group(BuxtonDaemon *self, client_list_item *client,
 
 /**
  * Buxton daemon function for getting a value
- * @param self bt-daemon instance being run
+ * @param self buxtond instance being run
  * @param client Used to validate smack access
  * @param key Key for the value being sought
  * @param status Will be set with the BuxtonStatus result of the operation
@@ -158,7 +158,7 @@ BuxtonData *get_value(BuxtonDaemon *self, client_list_item *client,
 
 /**
  * Buxton daemon function for unsetting a value
- * @param self bt-daemon instance being run
+ * @param self buxtond instance being run
  * @param client Used to validate smack access
  * @param key Key for the value being dunset
  * @param status Will be set with the BuxtonStatus result of the operation
@@ -168,7 +168,7 @@ void unset_value(BuxtonDaemon *self, client_list_item *client,
 
 /**
  * Buxton daemon function for listing keys in a given layer
- * @param self bt-daemon instance being run
+ * @param self buxtond instance being run
  * @param client Used to validate smack access
  * @param layer Layer to query
  * @param status Will be set with the BuxtonStatus result of the operation
@@ -179,7 +179,7 @@ BuxtonArray *list_keys(BuxtonDaemon *self, client_list_item *client,
 
 /**
  * Buxton daemon function for registering notifications on a given key
- * @param self bt-daemon instance being run
+ * @param self buxtond instance being run
  * @param client Used to validate smack access
  * @param key Key to notify for changes on
  * @param msgid Message ID from the client
@@ -191,7 +191,7 @@ void register_notification(BuxtonDaemon *self, client_list_item *client,
 
 /**
  * Buxton daemon function for unregistering notifications from the given key
- * @param self bt-daemon instance being run
+ * @param self buxtond instance being run
  * @param client Used to validate smack access
  * @param key Key to no longer recieve notifications for
  * @param status Will be set with the BuxtonStatus result of the operation
@@ -211,7 +211,7 @@ bool identify_client(client_list_item *cl)
 
 /**
  * Add a fd to daemon's poll list
- * @param self bt-daemon instance being run
+ * @param self buxtond instance being run
  * @param fd File descriptor to add to the poll list
  * @param events Priority mask for events
  * @param a Accepting status of the fd
@@ -221,7 +221,7 @@ void add_pollfd(BuxtonDaemon *self, int fd, short events, bool a);
 
 /**
  * Add a fd to daemon's poll list
- * @param self bt-daemon instance being run
+ * @param self buxtond instance being run
  * @param i File descriptor to remove from poll list
  * @return None
  */
@@ -229,7 +229,7 @@ void del_pollfd(BuxtonDaemon *self, nfds_t i);
 
 /**
  * Handle a client connection
- * @param self bt-daemon instance being run
+ * @param self buxtond instance being run
  * @param cl The currently activate client
  * @param i The currently active file descriptor
  * @return bool indicating more data to process
@@ -239,7 +239,7 @@ bool handle_client(BuxtonDaemon *self, client_list_item *cl, nfds_t i)
 
 /**
  * Terminate client connectoin
- * @param self bt-daemon instance being run
+ * @param self buxtond instance being run
  * @param cl The client to terminate
  * @param i File descriptor to remove from poll list
  */

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -65,7 +65,7 @@ static void print_usage(char *name)
 }
 
 /**
- * Entry point into bt-daemon
+ * Entry point into buxtond
  * @param argc Number of arguments passed
  * @param argv An array of string arguments
  * @returns EXIT_SUCCESS if the operation succeeded, otherwise EXIT_FAILURE

--- a/src/security/smack.h
+++ b/src/security/smack.h
@@ -49,7 +49,7 @@ typedef enum BuxtonKeyAccessType {
 } BuxtonKeyAccessType;
 
 /**
- * Check whether Smack is enabled in bt-daemon
+ * Check whether Smack is enabled in buxtond
  * @return a boolean value, indicating whether Smack is enabled
  */
 bool buxton_smack_enabled(void)

--- a/src/shared/protocol.h
+++ b/src/shared/protocol.h
@@ -44,7 +44,7 @@ void cleanup_callbacks(void);
  * @param callback User callback function executed
  * @param data User data passed to callback function
  * @param count number of elements in list
- * @param list Data from bt-daemon
+ * @param list Data from buxtond
  * @param type Message type of the callback
  * @param key Key used to make the request
  */
@@ -53,14 +53,14 @@ void run_callback(BuxtonCallback callback, void *data, size_t count,
 		  _BuxtonKey *key);
 
 /**
- * Write message to bt-daemon
+ * Write message to buxtond
  * @param client Client connection
- * @param send serialized data to send to bt-daemon
+ * @param send serialized data to send to buxtond
  * @param send_len size of send
- * @param callback Callback function used to handle bt-daemon's response
+ * @param callback Callback function used to handle buxtond's response
  * @param data User data passed to callback function
- * @param msgid Message id used to identify bt-daemon's response
- * @param type The type of request being sent to bt-daemon
+ * @param msgid Message id used to identify buxtond's response
+ * @param type The type of request being sent to buxtond
  * @return a boolean value, indicating success of the operation
  */
 bool send_message(_BuxtonClient *client, uint8_t *send, size_t send_len,
@@ -79,7 +79,7 @@ void handle_callback_response(BuxtonControlMessage msg, uint64_t msgid,
 			      BuxtonData *list, size_t count);
 
 /**
- * Parse responses from bt-daemon and run callbacks on received messages
+ * Parse responses from buxtond and run callbacks on received messages
  * @param client A BuxtonClient
  * @return number of received messages processed
  */
@@ -88,7 +88,7 @@ ssize_t buxton_wire_handle_response(_BuxtonClient *client)
 	__attribute__((warn_unused_result));
 
 /**
- * Wait for a response from bt-daemon and then call handle response
+ * Wait for a response from buxtond and then call handle response
  * @param client Client connection
  * @return a boolean value, indicating success of the operation
  */

--- a/test/check_daemon.c
+++ b/test/check_daemon.c
@@ -110,9 +110,9 @@ static void exec_daemon(void)
 	char path[PATH_MAX];
 
 	//FIXME: path is wrong for makedistcheck
-	snprintf(path, PATH_MAX, "%s/check_bt_daemon", get_current_dir_name());
+	snprintf(path, PATH_MAX, "%s/check_buxtond", get_current_dir_name());
 
-	if (execl(path, "check_bt_daemon", (const char*)NULL) < 0) {
+	if (execl(path, "check_buxtond", (const char*)NULL) < 0) {
 		fail("couldn't exec: %m");
 	}
 	fail("should never reach here");
@@ -971,7 +971,7 @@ START_TEST(register_notification_check)
 	buxton_direct_close(&server.buxton);
 }
 END_TEST
-START_TEST(bt_daemon_handle_message_error_check)
+START_TEST(buxtond_handle_message_error_check)
 {
 	int client, server;
 	BuxtonDaemon daemon;
@@ -1006,7 +1006,7 @@ START_TEST(bt_daemon_handle_message_error_check)
 	cl.data[2] = 0;
 	cl.data[3] = 0;
 	size = 100;
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	fail_if(r, "Failed to detect invalid message data");
 	free(cl.data);
 
@@ -1019,11 +1019,11 @@ START_TEST(bt_daemon_handle_message_error_check)
 	fail_if(size == 0, "Failed to serialize message");
 	control = BUXTON_CONTROL_MIN;
 	memcpy(cl.data, &control, sizeof(uint16_t));
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	fail_if(r, "Failed to detect min control size");
 	control = BUXTON_CONTROL_MAX;
 	memcpy(cl.data, &control, sizeof(uint16_t));
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	free(cl.data);
 	fail_if(r, "Failed to detect max control size");
 
@@ -1033,7 +1033,7 @@ START_TEST(bt_daemon_handle_message_error_check)
 }
 END_TEST
 
-START_TEST(bt_daemon_handle_message_create_group_check)
+START_TEST(buxtond_handle_message_create_group_check)
 {
 	BuxtonDaemon daemon;
 	BuxtonString slabel;
@@ -1084,7 +1084,7 @@ START_TEST(bt_daemon_handle_message_create_group_check)
 	size = buxton_serialize_message(&cl.data, BUXTON_CONTROL_CREATE_GROUP, 0,
 					out_list1);
 	fail_if(size == 0, "Failed to serialize message");
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	free(cl.data);
 	fail_if(!r, "Failed to handle create group message");
 
@@ -1113,7 +1113,7 @@ START_TEST(bt_daemon_handle_message_create_group_check)
 	size = buxton_serialize_message(&cl.data, BUXTON_CONTROL_CREATE_GROUP, 1,
 					out_list2);
 	fail_if(size == 0, "Failed to serialize message");
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	free(cl.data);
 	fail_if(!r, "Failed to handle create group message");
 
@@ -1139,7 +1139,7 @@ START_TEST(bt_daemon_handle_message_create_group_check)
 }
 END_TEST
 
-START_TEST(bt_daemon_handle_message_remove_group_check)
+START_TEST(buxtond_handle_message_remove_group_check)
 {
 	BuxtonDaemon daemon;
 	BuxtonString slabel;
@@ -1190,7 +1190,7 @@ START_TEST(bt_daemon_handle_message_remove_group_check)
 	size = buxton_serialize_message(&cl.data, BUXTON_CONTROL_REMOVE_GROUP, 0,
 					out_list);
 	fail_if(size == 0, "Failed to serialize message");
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	free(cl.data);
 	fail_if(!r, "Failed to handle remove group message");
 
@@ -1215,7 +1215,7 @@ START_TEST(bt_daemon_handle_message_remove_group_check)
 }
 END_TEST
 
-START_TEST(bt_daemon_handle_message_set_label_check)
+START_TEST(buxtond_handle_message_set_label_check)
 {
 	BuxtonDaemon daemon;
 	BuxtonString slabel;
@@ -1270,7 +1270,7 @@ START_TEST(bt_daemon_handle_message_set_label_check)
 	size = buxton_serialize_message(&cl.data, BUXTON_CONTROL_SET_LABEL, 0,
 					out_list);
 	fail_if(size == 0, "Failed to serialize message");
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	free(cl.data);
 	fail_if(!r, "Failed to handle set label message");
 
@@ -1295,7 +1295,7 @@ START_TEST(bt_daemon_handle_message_set_label_check)
 }
 END_TEST
 
-START_TEST(bt_daemon_handle_message_set_value_check)
+START_TEST(buxtond_handle_message_set_value_check)
 {
 	BuxtonDaemon daemon;
 	BuxtonString slabel;
@@ -1353,14 +1353,14 @@ START_TEST(bt_daemon_handle_message_set_value_check)
 	size = buxton_serialize_message(&cl.data, BUXTON_CONTROL_NOTIFY, 0,
 					out_list);
 	fail_if(size == 0, "Failed to serialize message");
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	free(cl.data);
 	fail_if(r, "Failed to detect parse_list failure");
 
 	size = buxton_serialize_message(&cl.data, BUXTON_CONTROL_SET, 0,
 					out_list);
 	fail_if(size == 0, "Failed to serialize message");
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	free(cl.data);
 	fail_if(!r, "Failed to handle set message");
 
@@ -1385,7 +1385,7 @@ START_TEST(bt_daemon_handle_message_set_value_check)
 }
 END_TEST
 
-START_TEST(bt_daemon_handle_message_get_check)
+START_TEST(buxtond_handle_message_get_check)
 {
 	int client, server;
 	BuxtonDaemon daemon;
@@ -1438,7 +1438,7 @@ START_TEST(bt_daemon_handle_message_get_check)
 	size = buxton_serialize_message(&cl.data, BUXTON_CONTROL_GET, 0,
 					out_list);
 	fail_if(size == 0, "Failed to serialize message");
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	free(cl.data);
 	fail_if(!r, "Failed to get message 1");
 
@@ -1470,7 +1470,7 @@ START_TEST(bt_daemon_handle_message_get_check)
 	size = buxton_serialize_message(&cl.data, BUXTON_CONTROL_GET, 0,
 					out_list2);
 	fail_if(size == 0, "Failed to serialize message 2");
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	free(cl.data);
 	fail_if(!r, "Failed to get message 2");
 
@@ -1497,7 +1497,7 @@ START_TEST(bt_daemon_handle_message_get_check)
 }
 END_TEST
 
-START_TEST(bt_daemon_handle_message_notify_check)
+START_TEST(buxtond_handle_message_notify_check)
 {
 	int client, server;
 	BuxtonDaemon daemon;
@@ -1547,7 +1547,7 @@ START_TEST(bt_daemon_handle_message_notify_check)
 	size = buxton_serialize_message(&cl.data, BUXTON_CONTROL_NOTIFY, 0,
 					out_list);
 	fail_if(size == 0, "Failed to serialize message");
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	free(cl.data);
 	fail_if(!r, "Failed to register for notification");
 
@@ -1568,7 +1568,7 @@ START_TEST(bt_daemon_handle_message_notify_check)
 	size = buxton_serialize_message(&cl.data, BUXTON_CONTROL_UNNOTIFY, 0,
 					out_list);
 	fail_if(size == 0, "Failed to serialize message");
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	free(cl.data);
 	fail_if(!r, "Failed to unregister from notification");
 
@@ -1596,7 +1596,7 @@ START_TEST(bt_daemon_handle_message_notify_check)
 }
 END_TEST
 
-START_TEST(bt_daemon_handle_message_unset_check)
+START_TEST(buxtond_handle_message_unset_check)
 {
 	int client, server;
 	BuxtonDaemon daemon;
@@ -1650,7 +1650,7 @@ START_TEST(bt_daemon_handle_message_unset_check)
 	size = buxton_serialize_message(&cl.data, BUXTON_CONTROL_UNSET, 0,
 					out_list);
 	fail_if(size == 0, "Failed to serialize message");
-	r = bt_daemon_handle_message(&daemon, &cl, size);
+	r = buxtond_handle_message(&daemon, &cl, size);
 	free(cl.data);
 	fail_if(!r, "Failed to unset message");
 
@@ -1674,7 +1674,7 @@ START_TEST(bt_daemon_handle_message_unset_check)
 }
 END_TEST
 
-START_TEST(bt_daemon_notify_clients_check)
+START_TEST(buxtond_notify_clients_check)
 {
 	int client, server;
 	BuxtonDaemon daemon;
@@ -1711,7 +1711,7 @@ START_TEST(bt_daemon_notify_clients_check)
 	value1.type = STRING;
 	value1.store.d_string = buxton_string_pack("dummy value");
 	key.group = buxton_string_pack("dummy key");
-	bt_daemon_notify_clients(&daemon, &cl, &key, &value1);
+	buxtond_notify_clients(&daemon, &cl, &key, &value1);
 
 	value1.store.d_string = buxton_string_pack("real value");
 	key.group = buxton_string_pack("daemon-check");
@@ -1724,11 +1724,11 @@ START_TEST(bt_daemon_notify_clients_check)
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != BUXTON_STATUS_OK,
 		"Failed to register notification for notify");
-	bt_daemon_notify_clients(&daemon, &cl, &key, &value1);
+	buxtond_notify_clients(&daemon, &cl, &key, &value1);
 
 	value2.type = STRING;
 	value2.store.d_string = buxton_string_pack("new value");
-	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
+	buxtond_notify_clients(&daemon, &cl, &key, &value2);
 
 	s = read(client, buf, 4096);
 	fail_if(s < 0, "Read from client failed");
@@ -1767,7 +1767,7 @@ START_TEST(bt_daemon_notify_clients_check)
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != BUXTON_STATUS_OK,
 		"Failed to register notification for notify");
-	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
+	buxtond_notify_clients(&daemon, &cl, &key, &value2);
 
 	s = read(client, buf, 4096);
 	fail_if(s < 0, "Read from client failed");
@@ -1797,7 +1797,7 @@ START_TEST(bt_daemon_notify_clients_check)
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != BUXTON_STATUS_OK,
 		"Failed to register notification for notify");
-	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
+	buxtond_notify_clients(&daemon, &cl, &key, &value2);
 
 	s = read(client, buf, 4096);
 	fail_if(s < 0, "Read from client failed");
@@ -1827,7 +1827,7 @@ START_TEST(bt_daemon_notify_clients_check)
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != BUXTON_STATUS_OK,
 		"Failed to register notification for notify");
-	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
+	buxtond_notify_clients(&daemon, &cl, &key, &value2);
 
 	s = read(client, buf, 4096);
 	fail_if(s < 0, "Read from client failed");
@@ -1857,7 +1857,7 @@ START_TEST(bt_daemon_notify_clients_check)
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != BUXTON_STATUS_OK,
 		"Failed to register notification for notify");
-	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
+	buxtond_notify_clients(&daemon, &cl, &key, &value2);
 
 	s = read(client, buf, 4096);
 	fail_if(s < 0, "Read from client failed");
@@ -1887,7 +1887,7 @@ START_TEST(bt_daemon_notify_clients_check)
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != BUXTON_STATUS_OK,
 		"Failed to register notification for notify");
-	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
+	buxtond_notify_clients(&daemon, &cl, &key, &value2);
 
 	s = read(client, buf, 4096);
 	fail_if(s < 0, "Read from client failed");
@@ -1917,7 +1917,7 @@ START_TEST(bt_daemon_notify_clients_check)
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != BUXTON_STATUS_OK,
 		"Failed to register notification for notify");
-	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
+	buxtond_notify_clients(&daemon, &cl, &key, &value2);
 
 	s = read(client, buf, 4096);
 	fail_if(s < 0, "Read from client failed");
@@ -1947,7 +1947,7 @@ START_TEST(bt_daemon_notify_clients_check)
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != BUXTON_STATUS_OK,
 		"Failed to register notification for notify");
-	bt_daemon_notify_clients(&daemon, &cl, &key, &value2);
+	buxtond_notify_clients(&daemon, &cl, &key, &value2);
 
 	s = read(client, buf, 4096);
 	fail_if(s < 0, "Read from client failed");
@@ -2067,7 +2067,7 @@ START_TEST(handle_client_check)
 }
 END_TEST
 
-START_TEST(bt_daemon_eat_garbage_check)
+START_TEST(buxtond_eat_garbage_check)
 {
 	daemon_pid = 0;
 	sigset_t sigset;
@@ -2182,15 +2182,15 @@ daemon_suite(void)
 	tcase_add_test(tc, set_value_check);
 	tcase_add_test(tc, get_value_check);
 	tcase_add_test(tc, register_notification_check);
-	tcase_add_test(tc, bt_daemon_handle_message_error_check);
-	tcase_add_test(tc, bt_daemon_handle_message_create_group_check);
-	tcase_add_test(tc, bt_daemon_handle_message_remove_group_check);
-	tcase_add_test(tc, bt_daemon_handle_message_set_label_check);
-	tcase_add_test(tc, bt_daemon_handle_message_set_value_check);
-	tcase_add_test(tc, bt_daemon_handle_message_get_check);
-	tcase_add_test(tc, bt_daemon_handle_message_notify_check);
-	tcase_add_test(tc, bt_daemon_handle_message_unset_check);
-	tcase_add_test(tc, bt_daemon_notify_clients_check);
+	tcase_add_test(tc, buxtond_handle_message_error_check);
+	tcase_add_test(tc, buxtond_handle_message_create_group_check);
+	tcase_add_test(tc, buxtond_handle_message_remove_group_check);
+	tcase_add_test(tc, buxtond_handle_message_set_label_check);
+	tcase_add_test(tc, buxtond_handle_message_set_value_check);
+	tcase_add_test(tc, buxtond_handle_message_get_check);
+	tcase_add_test(tc, buxtond_handle_message_notify_check);
+	tcase_add_test(tc, buxtond_handle_message_unset_check);
+	tcase_add_test(tc, buxtond_notify_clients_check);
 	tcase_add_test(tc, identify_client_check);
 	tcase_add_test(tc, add_pollfd_check);
 	tcase_add_test(tc, del_pollfd_check);
@@ -2199,7 +2199,7 @@ daemon_suite(void)
 
 	tc = tcase_create("buxton daemon evil tests");
 	tcase_add_checked_fixture(tc, NULL, teardown);
-	tcase_add_test(tc, bt_daemon_eat_garbage_check);
+	tcase_add_test(tc, buxtond_eat_garbage_check);
 	tcase_set_timeout(tc, fuzz_time+2);
 	suite_add_tcase(s, tc);
 

--- a/test/check_smack.c
+++ b/test/check_smack.c
@@ -41,9 +41,9 @@ static void exec_daemon(void)
 	char path[PATH_MAX];
 
 	//FIXME: path is wrong for makedistcheck
-	snprintf(path, PATH_MAX, "%s/check_bt_daemon", get_current_dir_name());
+	snprintf(path, PATH_MAX, "%s/check_buxtond", get_current_dir_name());
 
-	if (execl(path, "check_bt_daemon", (const char*)NULL) < 0) {
+	if (execl(path, "check_buxtond", (const char*)NULL) < 0) {
 		fail("couldn't exec: %m");
 	}
 	fail("should never reach here");


### PR DESCRIPTION
Like bt-daemon.h was renamed, it's reasonable to rename daemon's name
too, due ambiguity with BlueTooth. bt-daemon could confuse
developers, buxtond is more straightforward, such approach widely used
(systemd, connmand).

Signed-off-by: Alexey Perevalov a.perevalov@samsung.com
