### PR TITLE
Error handling patch 2

### DIFF
--- a/src/cli/client.c
+++ b/src/cli/client.c
@@ -33,7 +33,7 @@ bool cli_set_label(BuxtonControl *control, BuxtonDataType type,
 {
 	BuxtonString label;
 	BuxtonKey key;
-	bool ret = false;
+	int32_t ret;
 
 	if (four != NULL)
 		key = buxton_key_create(two, three, one, type);
@@ -41,7 +41,7 @@ bool cli_set_label(BuxtonControl *control, BuxtonDataType type,
 		key = buxton_key_create(two, NULL, one, type);
 
 	if (!key)
-		return ret;
+		return false;
 
 	if (four != NULL)
 		label = buxton_string_pack(four);
@@ -54,39 +54,43 @@ bool cli_set_label(BuxtonControl *control, BuxtonDataType type,
 		ret = buxton_set_label(&control->client, key, label.value,
 					      NULL, NULL, true);
 
-	if (!ret) {
+	if (ret) {
 		char *name = get_name(key);
 		printf("Failed to update key \'%s:%s\' label in layer '%s'\n",
 		       two, name, one);
 		free(name);
 	}
 	buxton_key_free(key);
-	return ret;
+	if (ret)
+		return false;
+	return true;
 }
 
 bool cli_create_group(BuxtonControl *control, BuxtonDataType type,
 		      char *one, char *two, char *three, char *four)
 {
 	BuxtonKey key;
-	bool ret = false;
+	int32_t ret = -1;
 
 	key = buxton_key_create(two, NULL, one, type);
 	if (!key)
-		return ret;
+		return false;
 
 	if (control->client.direct)
 		ret = buxton_direct_create_group(control, (_BuxtonKey *)key, NULL);
 	else
 		ret = buxton_create_group(&control->client, key, NULL, NULL, true);
 
-	if (!ret) {
+	if (ret) {
 		char *group = get_group(key);
 		printf("Failed to create group \'%s\' in layer '%s'\n",
 		       group, one);
 		free(group);
 	}
 	buxton_key_free(key);
-	return ret;
+	if (ret)
+		return false;
+	return true;
 }
 
 bool cli_remove_group(BuxtonControl *control, BuxtonDataType type,
@@ -128,12 +132,12 @@ bool cli_set_value(BuxtonControl *control, BuxtonDataType type,
 	BuxtonString value;
 	BuxtonKey key;
 	BuxtonData set;
-	bool ret = false;
+	int32_t ret = -1;
 
 	memzero((void*)&set, sizeof(BuxtonData));
 	key = buxton_key_create(two, three, one, type);
 	if (!key)
-		return ret;
+		return false;
 
 	value.value = four;
 	value.length = (uint32_t)strlen(four) + 1;
@@ -150,12 +154,13 @@ bool cli_set_value(BuxtonControl *control, BuxtonDataType type,
 		else
 			ret = buxton_set_value(&control->client, key,
 						      four, NULL, NULL, true);
+
 		break;
 	case INT32:
 		set.store.d_int32 = (int32_t)strtol(four, NULL, 10);
 		if (errno) {
 			printf("Invalid int32_t value\n");
-			return ret;
+			return false;
 		}
 		if (control->client.direct)
 			ret = buxton_direct_set_value(control,
@@ -170,7 +175,7 @@ bool cli_set_value(BuxtonControl *control, BuxtonDataType type,
 		set.store.d_uint32 = (uint32_t)strtol(value.value, NULL, 10);
 		if (errno) {
 			printf("Invalid uint32_t value\n");
-			return ret;
+			return false;
 		}
 		if (control->client.direct)
 			ret = buxton_direct_set_value(control,
@@ -185,7 +190,7 @@ bool cli_set_value(BuxtonControl *control, BuxtonDataType type,
 		set.store.d_int64 = strtoll(value.value, NULL, 10);
 		if (errno) {
 			printf("Invalid int64_t value\n");
-			return ret;
+			return false;
 		}
 		if (control->client.direct)
 			ret = buxton_direct_set_value(control,
@@ -200,7 +205,7 @@ bool cli_set_value(BuxtonControl *control, BuxtonDataType type,
 		set.store.d_uint64 = strtoull(value.value, NULL, 10);
 		if (errno) {
 			printf("Invalid uint64_t value\n");
-			return ret;
+			return false;
 		}
 		if (control->client.direct)
 			ret = buxton_direct_set_value(control,
@@ -215,7 +220,7 @@ bool cli_set_value(BuxtonControl *control, BuxtonDataType type,
 		set.store.d_float = strtof(value.value, NULL);
 		if (errno) {
 			printf("Invalid float value\n");
-			return ret;
+			return false;
 		}
 		if (control->client.direct)
 			ret = buxton_direct_set_value(control,
@@ -230,7 +235,7 @@ bool cli_set_value(BuxtonControl *control, BuxtonDataType type,
 		set.store.d_double = strtod(value.value, NULL);
 		if (errno) {
 			printf("Invalid double value\n");
-			return ret;
+			return false;
 		}
 		if (control->client.direct)
 			ret = buxton_direct_set_value(control,
@@ -260,7 +265,7 @@ bool cli_set_value(BuxtonControl *control, BuxtonDataType type,
 			set.store.d_boolean = false;
 		else {
 			printf("Invalid bool value\n");
-			return ret;
+			return false;
 		}
 		if (control->client.direct)
 			ret = buxton_direct_set_value(control,
@@ -275,7 +280,7 @@ bool cli_set_value(BuxtonControl *control, BuxtonDataType type,
 		break;
 	}
 
-	if (!ret) {
+	if (ret) {
 		char *group = get_group(key);
 		char *name = get_name(key);
 		char *layer = get_layer(key);
@@ -288,7 +293,9 @@ bool cli_set_value(BuxtonControl *control, BuxtonDataType type,
 	}
 
 	free(key);
-	return ret;
+	if (ret)
+		return false;
+	return true;
 }
 
 void get_value_callback(BuxtonResponse response, void *data)

--- a/src/core/daemon.c
+++ b/src/core/daemon.c
@@ -473,8 +473,6 @@ void set_value(BuxtonDaemon *self, client_list_item *client, _BuxtonKey *key,
 	assert(value);
 	assert(status);
 
-	*status = -1;
-
 	buxton_debug("Daemon setting [%s][%s]\n",
 		     key->layer.value,
 		     key->group.value);
@@ -483,10 +481,7 @@ void set_value(BuxtonDaemon *self, client_list_item *client, _BuxtonKey *key,
 
 	//FIXME move direct functions to daemon only file
 	/* Use internal library to set value */
-	if (!buxton_direct_set_value(&self->buxton, key, value, client->smack_label))
-		return;
-
-	*status = 0;
+	*status = buxton_direct_set_value(&self->buxton, key, value, client->smack_label);
 	buxton_debug("Daemon set value completed\n");
 }
 
@@ -500,8 +495,6 @@ void set_label(BuxtonDaemon *self, client_list_item *client, _BuxtonKey *key,
 	assert(value);
 	assert(status);
 
-	*status = -1;
-
 	buxton_debug("Daemon setting [%s][%s]\n",
 		     key->layer.value,
 		     key->group.value);
@@ -509,10 +502,7 @@ void set_label(BuxtonDaemon *self, client_list_item *client, _BuxtonKey *key,
 	self->buxton.client.uid = client->cred.uid;
 
 	/* Use internal library to set label */
-	if (!buxton_direct_set_label(&self->buxton, key, &value->store.d_string))
-		return;
-
-	*status = 0;
+	*status = buxton_direct_set_label(&self->buxton, key, &value->store.d_string);
 	buxton_debug("Daemon set label completed\n");
 }
 
@@ -524,8 +514,6 @@ void create_group(BuxtonDaemon *self, client_list_item *client, _BuxtonKey *key,
 	assert(key);
 	assert(status);
 
-	*status = -1;
-
 	buxton_debug("Daemon setting [%s][%s]\n",
 		     key->layer.value,
 		     key->group.value);
@@ -533,10 +521,7 @@ void create_group(BuxtonDaemon *self, client_list_item *client, _BuxtonKey *key,
 	self->buxton.client.uid = client->cred.uid;
 
 	/* Use internal library to create group */
-	if (!buxton_direct_create_group(&self->buxton, key, client->smack_label))
-		return;
-
-	*status = 0;
+	*status = buxton_direct_create_group(&self->buxton, key, client->smack_label);
 	buxton_debug("Daemon create group completed\n");
 }
 

--- a/src/db/gdbm.c
+++ b/src/db/gdbm.c
@@ -86,11 +86,11 @@ static GDBM_FILE _db_for_resource(BuxtonLayer *layer)
 	return db;
 }
 
-static bool set_value(BuxtonLayer *layer, _BuxtonKey *key, BuxtonData *data,
+static int32_t set_value(BuxtonLayer *layer, _BuxtonKey *key, BuxtonData *data,
 		      BuxtonString *label)
 {
 	GDBM_FILE db;
-	int ret = -1;
+	int32_t ret = -1;
 	datum key_data;
 	datum value;
 	_cleanup_free_ uint8_t *data_store = NULL;
@@ -124,8 +124,10 @@ static bool set_value(BuxtonLayer *layer, _BuxtonKey *key, BuxtonData *data,
 	}
 
 	db = _db_for_resource(layer);
-	if (!db)
+	if (!db) {
+		buxton_debug("DB for layer [%s] not found\n", layer->name.value);
 		goto end;
+	}
 
 	size = buxton_serialize(data, label, &data_store);
 	if (size < BXT_MINIMUM_SIZE)
@@ -139,8 +141,8 @@ end:
 	free(key_data.dptr);
 
 	if (ret == -1)
-		return false;
-	return true;
+		return ret;
+	return 0;
 }
 
 static bool get_value(BuxtonLayer *layer, _BuxtonKey *key, BuxtonData *data,

--- a/src/db/memory.c
+++ b/src/db/memory.c
@@ -60,7 +60,7 @@ static Hashmap *_db_for_resource(BuxtonLayer *layer)
 	return db;
 }
 
-static bool set_value(BuxtonLayer *layer, _BuxtonKey *key, BuxtonData *data,
+static int32_t set_value(BuxtonLayer *layer, _BuxtonKey *key, BuxtonData *data,
 		      BuxtonString *label)
 {
 	Hashmap *db;
@@ -112,7 +112,7 @@ static bool set_value(BuxtonLayer *layer, _BuxtonKey *key, BuxtonData *data,
 	//FIXME replace value if already in db
 	hashmap_put(db, full_key, array);
 
-	return true;
+	return 0;
 
 fail:
 	buxton_array_free(&array, NULL);
@@ -125,7 +125,7 @@ fail:
 	free(label_copy);
 	free(full_key);
 
-	return false;
+	return -1;
 }
 
 static bool get_value(BuxtonLayer *layer, _BuxtonKey *key, BuxtonData *data,

--- a/src/shared/backend.h
+++ b/src/shared/backend.h
@@ -73,6 +73,21 @@ typedef bool (*module_value_func) (BuxtonLayer *layer, _BuxtonKey *key,
 				   BuxtonData *data, BuxtonString *label);
 
 /**
+ * !!! Temporary Only!  This allows us to move set_value() and callers to
+ * a errno-based error handling, while leaving get_*() alone.
+ * Will be removed with next error handling patch.
+ *
+ * Backend manipulation function
+ * @param layer The layer to manipulate or query
+ * @param key The key to manipulate or query
+ * @param data Set or get data, dependant on operation
+ * @param label The key's label
+ * @return a boolean value, indicating success of the operation
+ */
+typedef int32_t (*module_value_set_func) (BuxtonLayer *layer, _BuxtonKey *key,
+                   BuxtonData *data, BuxtonString *label);
+
+/**
  * Backend key list function
  * @param layer The layer to query
  * @param data Pointer to store BuxtonArray in
@@ -93,7 +108,7 @@ typedef void (*module_destroy_func) (void);
 typedef struct BuxtonBackend {
 	void *module; /**<Private handle to the module */
 	module_destroy_func destroy; /**<Destroy method */
-	module_value_func set_value; /**<Set value function */
+	module_value_set_func set_value; /**<Set value function */
 	module_value_func get_value; /**<Get value function */
 	module_list_func list_keys; /**<List keys function */
 	module_value_func unset_value; /**<Unset value function */

--- a/src/shared/direct.h
+++ b/src/shared/direct.h
@@ -44,9 +44,9 @@ void buxton_direct_close(BuxtonControl *control);
  * @param control An initialized control structure
  * @param key The key struct
  * @param label A BuxtonString containing the label to set
- * @return A boolean value, indicating success of the operation
+ * @return A int32_t value, indicating success of the operation
  */
-bool buxton_direct_set_label(BuxtonControl *control,
+int32_t buxton_direct_set_label(BuxtonControl *control,
 			     _BuxtonKey *key,
 			     BuxtonString *label)
 	__attribute__((warn_unused_result));
@@ -56,9 +56,9 @@ bool buxton_direct_set_label(BuxtonControl *control,
  * @param control An initialized control structure
  * @param key The key struct with group and layer members initialized
  * @param label The Smack label of the client
- * @return A boolean value, indicating success of the operation
+ * @return A int32_t value, indicating success of the operation
  */
-bool buxton_direct_create_group(BuxtonControl *control,
+int32_t buxton_direct_create_group(BuxtonControl *control,
 				_BuxtonKey *key,
 				BuxtonString *label)
 	__attribute__((warn_unused_result));
@@ -81,9 +81,9 @@ bool buxton_direct_remove_group(BuxtonControl *control,
  * @param key The key struct
  * @param data A struct containing the data to set
  * @param label The Smack label for the client
- * @return A boolean value, indicating success of the operation
+ * @return A int32_t value, indicating success of the operation
  */
-bool buxton_direct_set_value(BuxtonControl *control,
+int32_t buxton_direct_set_value(BuxtonControl *control,
 			     _BuxtonKey *key,
 			     BuxtonData *data,
 			     BuxtonString *label)

--- a/test/check_buxton.c
+++ b/test/check_buxton.c
@@ -53,7 +53,7 @@ START_TEST(buxton_direct_create_group_check)
 	group.group = buxton_string_pack("tgroup");
 	group.name = (BuxtonString){ NULL, 0 };
 	group.type = STRING;
-	fail_if(!buxton_direct_create_group(&c, &group, NULL),
+	fail_if(buxton_direct_create_group(&c, &group, NULL) != 0,
 		"Create group failed");
 }
 END_TEST
@@ -96,13 +96,13 @@ START_TEST(buxton_direct_set_value_check)
 	key.type = STRING;
 
 	c.client.uid = getuid();
-	fail_if(buxton_direct_create_group(&c, &group, NULL) == false,
+	fail_if(buxton_direct_create_group(&c, &group, NULL) != 0,
 		"Creating group failed.");
-	fail_if(buxton_direct_set_label(&c, &group, &glabel) == false,
+	fail_if(buxton_direct_set_label(&c, &group, &glabel) != 0,
 		"Setting group label failed.");
 	data.type = STRING;
 	data.store.d_string = buxton_string_pack("bxt_test_value");
-	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) == false,
+	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) != 0,
 		"Setting value in buxton directly failed.");
 	buxton_direct_close(&c);
 }
@@ -155,7 +155,7 @@ START_TEST(buxton_direct_get_value_check)
 	data.store.d_string = buxton_string_pack("bxt_test_value2");
 	fail_if(data.store.d_string.value == NULL,
 		"Failed to allocate test string.");
-	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) == false,
+	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) != 0,
 		"Failed to set second value.");
 	fail_if(buxton_direct_get_value(&c, &key, &result, &dlabel, NULL) == false,
 		"Retrieving value from buxton gdbm backend failed.");
@@ -193,13 +193,13 @@ START_TEST(buxton_memory_backend_check)
 		"Direct open failed without daemon.");
 
 	c.client.uid = getuid();
-	fail_if(buxton_direct_create_group(&c, &group, NULL) == false,
+	fail_if(buxton_direct_create_group(&c, &group, NULL) != 0,
 		"Creating group failed.");
-	fail_if(buxton_direct_set_label(&c, &group, &glabel) == false,
+	fail_if(buxton_direct_set_label(&c, &group, &glabel) != 0,
 		"Setting group label failed.");
 	data.type = STRING;
 	data.store.d_string = buxton_string_pack("bxt_test_value");
-	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) == false,
+	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) != 0,
 		"Setting value in buxton memory backend directly failed.");
 	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) == false,
 		"Retrieving value from buxton memory backend directly failed.");
@@ -273,18 +273,18 @@ START_TEST(buxton_set_label_check)
 	c.client.uid = 0;
 	fail_if(buxton_direct_open(&c) == false,
 		"Direct open failed without daemon.");
-	fail_if(buxton_direct_create_group(&c, &key, NULL) == false,
+	fail_if(buxton_direct_create_group(&c, &key, NULL) != 0,
 		"Creating group failed.");
-	fail_if(buxton_direct_set_label(&c, &key, &label) == false,
+	fail_if(buxton_direct_set_label(&c, &key, &label) != 0,
 		"Failed to set label as root user.");
 
 	c.client.uid = 1000;
 
 	if (skip_check)
-		fail_if(!buxton_direct_set_label(&c, &key, &label),
+		fail_if(buxton_direct_set_label(&c, &key, &label) != 0,
 			"Unable to set label with root check disabled");
 	else
-		fail_if(buxton_direct_set_label(&c, &key, &label),
+		fail_if(buxton_direct_set_label(&c, &key, &label) == 0,
 			"Able to set label as non-root user.");
 
 	buxton_direct_close(&c);
@@ -307,9 +307,9 @@ START_TEST(buxton_group_label_check)
 	c.client.uid = 0;
 	fail_if(buxton_direct_open(&c) == false,
 		"Direct open failed without daemon.");
-	fail_if(buxton_direct_create_group(&c, &key, NULL) == false,
+	fail_if(buxton_direct_create_group(&c, &key, NULL) != 0,
 		"Creating group failed.");
-	fail_if(buxton_direct_set_label(&c, &key, &label) == false,
+	fail_if(buxton_direct_set_label(&c, &key, &label) != 0,
 		"Failed to set group label.");
 	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) == false,
 		"Retrieving group label failed.");
@@ -338,9 +338,9 @@ START_TEST(buxton_name_label_check)
 	c.client.uid = 0;
 	fail_if(buxton_direct_open(&c) == false,
 		"Direct open failed without daemon.");
-	fail_if(buxton_direct_create_group(&c, &key, NULL) == false,
+	fail_if(buxton_direct_create_group(&c, &key, NULL) != 0,
 		"Creating group failed.");
-	fail_if(buxton_direct_set_label(&c, &key, &label) == false,
+	fail_if(buxton_direct_set_label(&c, &key, &label) != 0,
 		"Failed to set group label.");
 	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) == false,
 		"Retrieving group label failed.");
@@ -353,7 +353,7 @@ START_TEST(buxton_name_label_check)
 	key.name = buxton_string_pack("name-foo");
 	data.type = STRING;
 	data.store.d_string = buxton_string_pack("value1-foo");
-	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) == false,
+	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) != 0,
 		"Failed to set key name-foo.");
 	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) == false,
 		"Failed to get value for name-foo 1");
@@ -362,7 +362,7 @@ START_TEST(buxton_name_label_check)
 	fail_if(!streq(dlabel.value, "_"), "Failed to set default label");
 	free(dlabel.value);
 	free(result.store.d_string.value);
-	fail_if(buxton_direct_set_label(&c, &key, &label) == false,
+	fail_if(buxton_direct_set_label(&c, &key, &label) != 0,
 		"Failed to set name label.");
 	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) == false,
 		"Failed to get value for name-foo 2");
@@ -375,7 +375,7 @@ START_TEST(buxton_name_label_check)
 
 	/* modify the same key, with a new value, and validate the label */
 	data.store.d_string = buxton_string_pack("value2-foo");
-	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) == false,
+	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) != 0,
 		"Failed to modify key name-foo.");
 	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL) == false,
 		"Failed to get new value for name-foo.");
@@ -385,7 +385,7 @@ START_TEST(buxton_name_label_check)
 		"Key label has been modified.");
 
 	/* modify the key label directly once it has been created */
-	fail_if(buxton_direct_set_label(&c, &key, &label) == false,
+	fail_if(buxton_direct_set_label(&c, &key, &label) != 0,
 		"Failed to modify label on key.");
 
 	free(dlabel.value);

--- a/test/check_daemon.c
+++ b/test/check_daemon.c
@@ -1683,7 +1683,7 @@ START_TEST(buxtond_notify_clients_check)
 	BuxtonData value1, value2;
 	client_list_item cl;
 	int32_t status;
-	bool r;
+	int32_t ret;
 	BuxtonData *list;
 	BuxtonControlMessage msg;
 	size_t csize;
@@ -1718,9 +1718,9 @@ START_TEST(buxtond_notify_clients_check)
 	key.name = buxton_string_pack("name");
 	key.layer = buxton_string_pack("base");
 	key.type = STRING;
-	r = buxton_direct_set_value(&daemon.buxton, &key,
+	ret = buxton_direct_set_value(&daemon.buxton, &key,
 				    &value1, NULL);
-	fail_if(!r, "Failed to set value for notify");
+	fail_if(ret != 0, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != 0,
 		"Failed to register notification for notify");
@@ -1749,10 +1749,10 @@ START_TEST(buxtond_notify_clients_check)
 	key.group = buxton_string_pack("group");
 	key.name.value = NULL;
 	key.name.length = 0;
-	r = buxton_direct_create_group(&daemon.buxton, &key, NULL);
-	fail_if(!r, "Unable to create group");
-	r = buxton_direct_set_label(&daemon.buxton, &key, &slabel);
-	fail_if(!r, "Unable set group label");
+	ret = buxton_direct_create_group(&daemon.buxton, &key, NULL);
+	fail_if(ret != 0, "Unable to create group");
+	ret = buxton_direct_set_label(&daemon.buxton, &key, &slabel);
+	fail_if(ret != 0, "Unable set group label");
 
 	value1.type = INT32;
 	value1.store.d_int32 = 1;
@@ -1761,9 +1761,9 @@ START_TEST(buxtond_notify_clients_check)
 	key.group = buxton_string_pack("group");
 	key.name = buxton_string_pack("name32");
 	key.type = INT32;
-	r = buxton_direct_set_value(&daemon.buxton, &key,
+	ret = buxton_direct_set_value(&daemon.buxton, &key,
 				    &value1, NULL);
-	fail_if(!r, "Failed to set value for notify");
+	fail_if(ret != 0, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != 0,
 		"Failed to register notification for notify");
@@ -1791,9 +1791,9 @@ START_TEST(buxtond_notify_clients_check)
 	key.group = buxton_string_pack("group");
 	key.name = buxton_string_pack("nameu32");
 	key.type = UINT32;
-	r = buxton_direct_set_value(&daemon.buxton, &key,
+	ret = buxton_direct_set_value(&daemon.buxton, &key,
 				    &value1, NULL);
-	fail_if(!r, "Failed to set value for notify");
+	fail_if(ret != 0, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != 0,
 		"Failed to register notification for notify");
@@ -1821,9 +1821,9 @@ START_TEST(buxtond_notify_clients_check)
 	key.group = buxton_string_pack("group");
 	key.name = buxton_string_pack("name64");
 	key.type = INT64;
-	r = buxton_direct_set_value(&daemon.buxton, &key,
+	ret = buxton_direct_set_value(&daemon.buxton, &key,
 				    &value1, NULL);
-	fail_if(!r, "Failed to set value for notify");
+	fail_if(ret != 0, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != 0,
 		"Failed to register notification for notify");
@@ -1851,9 +1851,9 @@ START_TEST(buxtond_notify_clients_check)
 	key.group = buxton_string_pack("group");
 	key.name = buxton_string_pack("nameu64");
 	key.type = UINT64;
-	r = buxton_direct_set_value(&daemon.buxton, &key,
+	ret = buxton_direct_set_value(&daemon.buxton, &key,
 				    &value1, NULL);
-	fail_if(!r, "Failed to set value for notify");
+	fail_if(ret != 0, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != 0,
 		"Failed to register notification for notify");
@@ -1881,9 +1881,9 @@ START_TEST(buxtond_notify_clients_check)
 	key.group = buxton_string_pack("group");
 	key.name = buxton_string_pack("namef");
 	key.type = FLOAT;
-	r = buxton_direct_set_value(&daemon.buxton, &key,
+	ret = buxton_direct_set_value(&daemon.buxton, &key,
 				    &value1, NULL);
-	fail_if(!r, "Failed to set value for notify");
+	fail_if(ret != 0, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != 0,
 		"Failed to register notification for notify");
@@ -1911,9 +1911,9 @@ START_TEST(buxtond_notify_clients_check)
 	key.group = buxton_string_pack("group");
 	key.name = buxton_string_pack("named");
 	key.type = DOUBLE;
-	r = buxton_direct_set_value(&daemon.buxton, &key,
+	ret = buxton_direct_set_value(&daemon.buxton, &key,
 				    &value1, NULL);
-	fail_if(!r, "Failed to set value for notify");
+	fail_if(ret != 0, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != 0,
 		"Failed to register notification for notify");
@@ -1941,9 +1941,9 @@ START_TEST(buxtond_notify_clients_check)
 	key.group = buxton_string_pack("group");
 	key.name = buxton_string_pack("nameb");
 	key.type = BOOLEAN;
-	r = buxton_direct_set_value(&daemon.buxton, &key,
+	ret = buxton_direct_set_value(&daemon.buxton, &key,
 				    &value1, NULL);
-	fail_if(!r, "Failed to set value for notify");
+	fail_if(ret != 0, "Failed to set value for notify");
 	register_notification(&daemon, &cl, &key, 0, &status);
 	fail_if(status != 0,
 		"Failed to register notification for notify");
@@ -2172,6 +2172,7 @@ daemon_suite(void)
 	tcase_add_test(tc, buxton_set_label_check);
 	tcase_add_test(tc, buxton_get_value_for_layer_check);
 	tcase_add_test(tc, buxton_get_value_check);
+
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("buxton_daemon_functions");
@@ -2196,6 +2197,7 @@ daemon_suite(void)
 	tcase_add_test(tc, del_pollfd_check);
 	tcase_add_test(tc, handle_client_check);
 	suite_add_tcase(s, tc);
+
 
 	tc = tcase_create("buxton daemon evil tests");
 	tcase_add_checked_fixture(tc, NULL, teardown);


### PR DESCRIPTION
This patch moves the various setter functions, including -

set_value
set_label
create_group
(and friends)

Over to a errno-based error reporting system. Note that some
shim code was necessary, in order to allow just these functions
to be updated.

Signed-off by Brad Peters brad.t.peters@intel.com
