### PR TITLE
library man pages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -68,7 +68,29 @@ dist_man_MANS = \
 	docs/buxton.conf.5 \
 	docs/buxtond.8 \
 	docs/buxton-protocol.7 \
-	docs/buxton-security.7
+	docs/buxton-security.7 \
+	docs/buxton_client_handle_response.3 \
+	docs/buxton_close.3 \
+	docs/buxton_create_group.3 \
+	docs/buxton_get_value.3 \
+	docs/buxton_key_create.3 \
+	docs/buxton_key_free.3 \
+	docs/buxton_key_get_group.3 \
+	docs/buxton_key_get_layer.3 \
+	docs/buxton_key_get_name.3 \
+	docs/buxton_key_get_type.3 \
+	docs/buxton_open.3 \
+	docs/buxton_register_notification.3 \
+	docs/buxton_remove_group.3 \
+	docs/buxton_response_key.3 \
+	docs/buxton_response_status.3 \
+	docs/buxton_response_type.3 \
+	docs/buxton_response_value.3 \
+	docs/buxton_set_conf_file.3 \
+	docs/buxton_set_label.3 \
+	docs/buxton_set_value.3 \
+	docs/buxton_unregister_notification.3 \
+	docs/buxton_unset_value.3
 
 TESTS = \
 	check_db_clean \

--- a/docs/buxton_client_handle_response.3
+++ b/docs/buxton_client_handle_response.3
@@ -1,0 +1,51 @@
+'\" t
+.TH "BUXTON_CLIENT_HANDLE_RESPONSE" "3" "buxton 1" "buxton_client_handle_response"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+buxton_client_handle_response \- Notification response helper
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxton.h>
+\fR
+.sp
+\fB
+ssize_t buxton_client_handle_response(BuxtonClient \fIclient\fB)
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+This function retrieves the response from \fBbuxtond\fR for the \fIclient\fR.
+
+Several manual pages include code examples that use this function.
+For an example, see \fBbuxton_create_group\fR(3).
+
+.SH "RETURN VALUE"
+.PP
+Returns the number of messages processed, or -1 if there was an error\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7),
+\fBbuxtond\fR(8),
+\fBbuxton\-api\fR(7)

--- a/docs/buxton_close.3
+++ b/docs/buxton_close.3
@@ -1,0 +1,1 @@
+.so buxton_open.3

--- a/docs/buxton_create_group.3
+++ b/docs/buxton_create_group.3
@@ -1,0 +1,218 @@
+'\" t
+.TH "BUXTON_CREATE_GROUP" "3" "buxton 1" "buxton_create_group"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+buxton_create_group, buxton_remove_group \- Manage groups within buxton
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxton.h>
+\fR
+.sp
+\fB
+bool buxton_create_group(BuxtonClient \fIclient\fB,
+.br
+                         BuxtonKey \fIkey\fB,
+.br
+                         BuxtonCallback \fIcallback\fB,
+.br
+                         void *\fIdata\fB,
+.br
+                         bool \fIsync\fB)
+.sp
+.br
+bool buxton_remove_group(BuxtonClient \fIclient\fB,
+.br
+                         BuxtonKey \fIkey\fB,
+.br
+                         BuxtonCallback \fIcallback\fB,
+.br
+                         void *\fIdata\fB,
+.br
+                         bool \fIsync\fB)
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+These functions are used for managing groups within buxton\&.
+
+Before a value can be set for a key-name, the group for the key-name
+must be created\&. A group can be created by calling
+\fBbuxton_create_group\fR(3). Creating a group is done on behalf of
+\fIclient\fR, and the BuxtonKey, \fIkey\fR, is group to be created\&.
+For more information about BuxtonKeys, see
+\fBbuxton_key_create\fR(3)\&.
+
+Groups can also be removed by calling \fBbuxton_remove_group\fR(3)\&.
+Note that this operation is recursive, removing all key-names within
+a group, and the group itself\&.
+
+Both functions accept optional callback functions to register with
+the daemon, referenced by the \fIcallback\fR argument; the callback
+function is called upon completion of the operation\&. The \fIdata\fR
+argument is a pointer to arbitrary userdata that is passed along to
+the callback function\&. Additonally, the \fIsync\fR argument
+controls whether the operation should be synchronous or not; if
+\fIsync\fR is false, the operation is asynchronous\&.
+
+.SH "CODE EXAMPLE"
+.PP
+An example for \fBbuxton_create_group\fR(3):
+
+.nf
+.sp
+#define _GNU_SOURCE
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "buxton.h"
+
+void create_cb(BuxtonResponse response, void *data)
+{
+	if (buxton_response_status(response) != BUXTON_STATUS_OK) {
+		printf("Failed to create group\\n");
+	} else {
+		printf("Created group\\n");
+	}
+}
+
+int main(void)
+{
+	BuxtonClient client;
+	BuxtonKey key;
+	struct pollfd pfd[1];
+	int r;
+	int fd;
+
+	if ((fd = buxton_open(&client)) < 0) {
+		printf("couldn't connect\\n");
+		return -1;
+	}
+
+	key = buxton_key_create("hello", NULL, "user", STRING);
+	if (!key)
+		return -1;
+
+	if (!buxton_create_group(client, key, create_cb,
+				     NULL, false)) {
+		printf("create group call failed to run\\n");
+		return -1;
+	}
+
+	pfd[0].fd = fd;
+	pfd[0].events = POLLIN;
+	pfd[0].revents = 0;
+	r = poll(pfd, 1, 5000);
+
+	if (r <= 0) {
+		printf("poll error\\n");
+		return -1;
+	}
+
+	if (!buxton_client_handle_response(client)) {
+		printf("bad response from daemon\\n");
+		return -1;
+	}
+
+	buxton_key_free(key);
+	buxton_close(client);
+	return 0;
+}
+.fi
+
+An example for \fBbuxton_remove_group\fR(3):
+
+.nf
+.sp
+#define _GNU_SOURCE
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "buxton.h"
+
+void remove_cb(BuxtonResponse response, void *data)
+{
+	if (buxton_response_status(response) != BUXTON_STATUS_OK) {
+		printf("Failed to remove group\\n");
+	} else {
+		printf("Removed group\\n");
+	}
+}
+
+int main(void)
+{
+	BuxtonClient client;
+	BuxtonKey key;
+	struct pollfd pfd[1];
+	int r;
+	int fd;
+
+	if ((fd = buxton_open(&client)) < 0) {
+		printf("couldn't connect\\n");
+		return -1;
+	}
+
+	key = buxton_key_create("hello", NULL, "user", STRING);
+	if (!key)
+		return -1;
+
+	if (!buxton_remove_group(client, key, remove_cb,
+				     NULL, false)) {
+		printf("remove group call failed to run\\n");
+		return -1;
+	}
+
+	pfd[0].fd = fd;
+	pfd[0].events = POLLIN;
+	pfd[0].revents = 0;
+	r = poll(pfd, 1, 5000);
+
+	if (r <= 0) {
+		printf("poll error\\n");
+		return -1;
+	}
+
+	if (!buxton_client_handle_response(client)) {
+		printf("bad response from daemon\\n");
+		return -1;
+	}
+
+	buxton_key_free(key);
+	buxton_close(client);
+	return 0;
+}
+.fi
+
+.SH "RETURN VALUE"
+.PP
+Returns "true" on success, and "false" on failure\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7),
+\fBbuxtond\fR(8),
+\fBbuxton\-api\fR(7)

--- a/docs/buxton_get_value.3
+++ b/docs/buxton_get_value.3
@@ -1,0 +1,141 @@
+'\" t
+.TH "BUXTON_GET_VALUE" "3" "buxton 1" "buxton_get_value"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+buxton_get_value \- Get the value of a key\-name
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxton.h>
+\fR
+.sp
+\fB
+bool buxton_get_value(BuxtonClient \fIclient\fB,
+.br
+                      BuxtonKey \fIkey\fB,
+.br
+                      BuxtonCallback \fIcallback\fB,
+.br
+                      void *\fIdata\fB,
+.br
+                      bool \fIsync\fB)
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+This function is used to get the value of a key\-name for
+\fIclient\fR. The key\-name is referenced by \fIkey\fR. If the layer
+for \fIkey\fR is NULL, buxton will traverse layers in priority order
+searching for the key-name value, selecting the value for the first
+key\-name found\&. If the argument is non-NULL, the operation will
+target only that layer\&. For more information on creating a
+BuxtonKey to pass for \fIkey\fR, see \fBbuxton_key_create\fR(3)\&.
+
+To retrieve the result of the operation, clients should define a
+callback function, referenced by the \fIcallback\fR argument; the
+callback function is called upon completion of the operation\&. The
+\fIdata\fR argument is a pointer to arbitrary userdata that is passed
+along to the callback function\&. Additonally, the \fIsync\fR
+argument controls whether the operation should be synchronous or not;
+if \fIsync\fR is false, the operation is asynchronous\&.
+
+.SH "CODE EXAMPLE"
+.nf
+.sp
+#define _GNU_SOURCE
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "buxton.h"
+
+void get_cb(BuxtonResponse response, void *data)
+{
+	int32_t* ret = (int32_t*)data;
+
+	if (buxton_response_status(response) != BUXTON_STATUS_OK) {
+		printf("Failed to get value\\n");
+		return;
+	}
+
+	*ret = *(int32_t*)buxton_response_value(response);
+}
+
+int main(void)
+{
+	BuxtonClient client;
+	BuxtonKey key;
+	struct pollfd pfd[1];
+	int r;
+	int32_t gvalue = -1;
+	int fd;
+
+	if ((fd = buxton_open(&client)) < 0) {
+		printf("couldn't connect\\n");
+		return -1;
+	}
+
+	key = buxton_key_create("hello", "test", "user", INT32);
+	if (!key)
+		return -1;
+
+	if (!buxton_get_value(client, key, get_cb,
+					       &gvalue, false)) {
+		printf("get call failed to run\\n");
+		return -1;
+	}
+
+	pfd[0].fd = fd;
+	pfd[0].events = POLLIN;
+	pfd[0].revents = 0;
+	r = poll(pfd, 1, 5000);
+
+	if (r <= 0) {
+		printf("poll error\\n");
+		return -1;
+	}
+
+	if (!buxton_client_handle_response(client)) {
+		printf("bad response from daemon\\n");
+		return -1;
+	}
+
+	if (gvalue >= 0)
+		printf("got value: %d\\n", gvalue);
+
+	buxton_key_free(key);
+	buxton_close(client);
+	return 0;
+}
+.fi
+
+.SH "RETURN VALUE"
+.PP
+Returns "true" on success, and "false" on failure\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7),
+\fBbuxtond\fR(8),
+\fBbuxton\-api\fR(7)

--- a/docs/buxton_key_create.3
+++ b/docs/buxton_key_create.3
@@ -1,0 +1,97 @@
+'\" t
+.TH "BUXTON_KEY_CREATE" "3" "buxton 1" "buxton_key_create"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+buxton_key_create, buxton_key_free, buxton_key_get_layer,
+buxton_key_get_type, buxton_key_get_group, buxton_key_get_name \-
+Manage groups and key\-names for buxton clients
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxton.h>
+\fR
+.sp
+\fB
+BuxtonKey buxton_key_create(char *\fIgroup\fB,
+.br
+                            char *\fIname\fB,
+.br
+                            char *\fIlayer\fB,
+.br
+                            BuxtonDataType \fItype\fB)
+.sp
+.br
+char *buxton_key_get_layer(BuxtonKey \fIkey\fB)
+.sp
+.br
+char *buxton_key_get_group(BuxtonKey \fIkey\fB)
+.sp
+.br
+char *buxton_key_get_name(BuxtonKey \fIkey\fB)
+.sp
+.br
+BuxtonDataType buxton_key_get_type(BuxtonKey \fIkey\fB)
+.sp
+.br
+void buxton_key_free(BuxtonKey \fIkey\fB)
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+These functions are used by buxton clients to manage groups and
+key\-names, both represented by a BuxtonKey\&. BuxtonKeys are
+required for all configuration management operations within buxton.
+
+A BuxtonKey is created with \fBbuxton_key_create\fR(3). Its arguments
+serve to initialize the BuxtonKey contents, which include the name of
+the \fIlayer\fR, name of the \fIgroup\fR, name of the key \fIname\fR,
+and the \fItype\fR of the key name\&. Groups must be initialized by
+passing a NULL value for \fIname\fR; similarly, key\-names must be
+initialized by passing non\-NULL arguments for both \fIgroup\fR and
+\fIname\fR\&. For groups, the \fItype\fR is ignored\&. The function
+returns an initialized BuxtonKey\&.
+
+Note that upon creation, a BuxtonKey is either a group or key\-name,
+but not both\&. In other words, if a client needs to a create a group
+and key\-name within that group, two BuxtonKeys need to be created\&.
+
+After creating a BuxtonKey, its layer, group, key name, or key name
+type fields can be requested by calling
+\fBbuxton_key_get_layer\fR(3), \fBbuxton_key_get_group\fR(3),
+\fBbuxton_key_get_name\fR(3), or \fBbuxton_key_get_type\fR(3),
+respectively\&. Each of these functions take a single argument, the
+BuxtonKey that is being queried, and return the value requested\&.
+Note that calling \fBbuxton_key_get_type\fR(3) for a group will
+return STRING, since buxton treats groups as strings internally\&.
+Calling \fBbuxton_key_get_name\fR(3) for a group will return NULL,
+since the name field is not used for groups\&.
+
+When the client no longer needs a BuxtonKey, its memory should freed
+by calling \fBbuxton_key_free\fR(3)\&. This function takes a single
+argument, the BuxtonKey to be freed\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7),
+\fBbuxtond\fR(8),
+\fBbuxton\-api\fR(7)

--- a/docs/buxton_key_free.3
+++ b/docs/buxton_key_free.3
@@ -1,0 +1,1 @@
+.so buxton_key_create.3

--- a/docs/buxton_key_get_group.3
+++ b/docs/buxton_key_get_group.3
@@ -1,0 +1,1 @@
+.so buxton_key_create.3

--- a/docs/buxton_key_get_layer.3
+++ b/docs/buxton_key_get_layer.3
@@ -1,0 +1,1 @@
+.so buxton_key_create.3

--- a/docs/buxton_key_get_name.3
+++ b/docs/buxton_key_get_name.3
@@ -1,0 +1,1 @@
+.so buxton_key_create.3

--- a/docs/buxton_key_get_type.3
+++ b/docs/buxton_key_get_type.3
@@ -1,0 +1,1 @@
+.so buxton_key_create.3

--- a/docs/buxton_open.3
+++ b/docs/buxton_open.3
@@ -1,0 +1,80 @@
+'\" t
+.TH "BUXTON_OPEN" "3" "buxton 1" "buxton_open"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+buxton_open, buxton_close \- Manage buxton client connections
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxton.h>
+\fR
+.sp
+\fB
+int buxton_open(BuxtonClient *\fIclient\fB)
+.sp
+.br
+void buxton_close(BuxtonClient \fIclient\fB)
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+These functions are used to manage connections from a buxton client to the
+buxton daemon, \fBbuxtond\fR(8)\&. Clients must call \fBbuxton_open\fR(3), to
+create a new connection to the daemon\&. Effectively, creating this connection
+registers the client with the daemon, allowing the client to make configuration
+changes, queries, etc\&. This function requires one argument, \fIclient\fR, a
+pointer to a BuxtonClient owned by the client\&. It returns 0 on success,
+and a non-zero status code on failure\&.
+
+To terminate this connection, the client must call \fBbuxton_close\fR(3)\&. The
+required argument is a reference to the same BuxtonClient passed to
+\fBbuxton_open\fR(3)\&.
+
+.SH "CODE EXAMPLE"
+.nf
+.sp
+#define _GNU_SOURCE
+#include <buxton.h>
+
+int main(void)
+{
+	BuxtonClient client;
+	int fd;
+
+	if ((fd = buxton_open(&client)) < 0) {
+		printf("couldn't connect\\n");
+		return -1;
+	}
+
+	/* Manipulate data, register for notifications, ... */
+
+	buxton_close(client);
+	return 0;
+}
+.fi
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7),
+\fBbuxtond\fR(8),
+\fBbuxton\-api\fR(7)

--- a/docs/buxton_register_notification.3
+++ b/docs/buxton_register_notification.3
@@ -1,0 +1,175 @@
+'\" t
+.TH "BUXTON_REGISTER_NOTIFICATION" "3" "buxton 1" "buxton_register_notification"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+buxton_register_notification, buxton_unregister_notification \-
+Manage key-name notifications
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxton.h>
+\fR
+.sp
+\fB
+bool buxton_register_notification(BuxtonClient \fIclient\fB,
+.br
+                                  BuxtonKey \fIkey\fB,
+.br
+                                  BuxtonCallback \fIcallback\fB,
+.br
+                                  void *\fIdata\fB,
+.br
+                                  bool \fIsync\fB)
+.sp
+.br
+bool buxton_unregister_notification(BuxtonClient \fIclient\fB,
+.br
+                                    BuxtonKey \fIkey\fB,
+.br
+                                    BuxtonCallback \fIcallback\fB,
+.br
+                                    void *\fIdata\fB,
+.br
+                                    bool \fIsync\fB)
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+These functions are used to manage key\-name notifications on
+\fIkey\fR for \fIclient\fR.
+
+To register for notifications on a specific key\-name, the client
+should call \fBbuxton_register_notification\fR(3)\&. Similarly, to
+unregister for notifications, \fBbuxton_unregister_notification\fR(3)
+can be used\&.
+
+Both functions accept optional callback functions to register with
+the daemon, referenced by the \fIcallback\fR argument; the callback
+function is called upon completion of the operation\&. The \fIdata\fR
+argument is a pointer to arbitrary userdata that is passed along to
+the callback function\&.  Additonally, the \fIsync\fR argument
+controls whether the operation should be synchronous or not; if
+\fIsync\fR is false, the operation is asynchronous\&.
+
+.SH "CODE EXAMPLE"
+.PP
+Example for register_notification:
+
+.nf
+.sp
+#define _GNU_SOURCE
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "buxton.h"
+
+void notify_cb(BuxtonResponse response, void *data)
+{
+	bool *status = (bool *)data;
+	BuxtonKey key;
+	int32_t value;
+	char *name;
+
+	if (buxton_response_status(response) == BUXTON_STATUS_FAILED) {
+		*status = false;
+		return;
+	}
+
+	key = buxton_response_key(response);
+	name = buxton_key_get_name(key);
+
+	value = *(int32_t*)buxton_response_value(response);
+	printf("key %s updated with new value %d\\n", name, value);
+
+	buxton_key_free(key);
+	free(name);
+}
+
+int main(void)
+{
+	BuxtonClient client;
+	BuxtonKey key;
+	bool status = true;
+	struct pollfd pfd[1];
+	int r;
+	int fd;
+
+	if ((fd = buxton_open(&client)) < 0) {
+		printf("couldn't connect\\n");
+		return -1;
+	}
+
+	key = buxton_key_create("hello", "test", NULL, INT32);
+	if (!key)
+		return -1;
+
+	if (!buxton_register_notification(client, key, notify_cb, &status, false)) {
+		printf("set call failed to run\\n");
+		return -1;
+	}
+repoll:
+	pfd[0].fd = fd;
+	pfd[0].events = POLLIN;
+	pfd[0].revents = 0;
+	r = poll(pfd, 1, 5000);
+
+	if (r < 0) {
+		printf("poll error\\n");
+		return -1;
+	} else if (r == 0) {
+		goto repoll;
+	}
+
+	if (!buxton_client_handle_response(client)) {
+		printf("bad response from daemon\\n");
+		return -1;
+	}
+
+	if (!status) {
+		printf("Failed to register for notification\\n");
+		return -1;
+	}
+
+	goto repoll;
+
+	buxton_key_free(key);
+	buxton_close(client);
+
+	return 0;
+}
+
+.fi
+
+.PP
+Example for unregister_notification: TODO
+
+.SH "RETURN VALUE"
+.PP
+Returns "true" on success, and "false" on failure\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7),
+\fBbuxtond\fR(8),
+\fBbuxton\-api\fR(7)

--- a/docs/buxton_remove_group.3
+++ b/docs/buxton_remove_group.3
@@ -1,0 +1,1 @@
+.so buxton_create_group.3

--- a/docs/buxton_response_key.3
+++ b/docs/buxton_response_key.3
@@ -1,0 +1,1 @@
+.so buxton_response_status.3

--- a/docs/buxton_response_status.3
+++ b/docs/buxton_response_status.3
@@ -1,0 +1,82 @@
+'\" t
+.TH "BUXTON_RESPONSE_STATUS" "3" "buxton 1" "buxton_response_status"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+buxton_response_status, buxton_response_type, buxton_response_key,
+buxton_response_value \- Query responses from the buxton daemon
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxton.h>
+\fR
+.sp
+\fB
+int32_t buxton_reponse_status(BuxtonResponse \fIresponse\fB)
+.sp
+.br
+BuxtonControlMessage buxton_reponse_type(BuxtonResponse \fIresponse\fB)
+.sp
+.br
+BuxtonKey buxton_reponse_key(BuxtonResponse \fIresponse\fB)
+.sp
+.br
+void *buxton_reponse_value(BuxtonResponse \fIresponse\fB)
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+These functions are used within client-defined buxton callback
+functions to query the response returned to the client by the buxton
+daemon, \fBbuxtond\fR(8)\&. Callbacks are registered through several
+of the API functions, such as \fBbuxton_set_value\fR(3) or
+\fBbuxton_get_value\fR(3)\&.
+
+With a callback function, the client should check the response status
+by calling \fBbuxton_response_status\fR(3), with the \fIresponse\fR
+argument passed to the callback\&. This function returns 0 on
+success, or a non-zero value on failure\&.
+
+Next, the client will want to check the type of response received
+from the daemon by calling \fBbuxton_response_type\fR(3)\&. The type
+will correspond to the type of operation that the client originally
+requested\&. There are several possible return values, depending on
+the type of operation; for operations that manipulate or query
+configuration, the values include BUXTON_CONTROL_SET,
+BUXTON_CONTROL_SET_LABEL, BUXTON_CONTROL_CREATE_GROUP,
+BUXTON_CONTROL_REMOVE_GROUP, BUXTON_CONTROL_GET, and
+BUXTON_CONTROL_UNSET; for operations related to notifications, the
+values include BUXTON_CONTROL_NOTIFY and BUXTON_CONTROL_UNNOTIFY\&.
+
+Finally, the client can validate that the configuration action
+requested by the client matches the action taken by the daemon\&. To
+query the BuxtonKey operated on by the daemon, the client should call
+\fBbuxton_response_key\fR(3), which returns the BuxtonKey in
+question\&. To query the value acted on by the daemon for this
+BuxtonKey, a call to \fBbuxton_response_value\fR(3) returns an
+untyped pointer to this value\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7),
+\fBbuxtond\fR(8),
+\fBbuxton\-api\fR(7)

--- a/docs/buxton_response_type.3
+++ b/docs/buxton_response_type.3
@@ -1,0 +1,1 @@
+.so buxton_response_status.3

--- a/docs/buxton_response_value.3
+++ b/docs/buxton_response_value.3
@@ -1,0 +1,1 @@
+.so buxton_response_status.3

--- a/docs/buxton_set_conf_file.3
+++ b/docs/buxton_set_conf_file.3
@@ -1,0 +1,77 @@
+'\" t
+.TH "BUXTON_SET_CONF_FILE" "3" "buxton 1" "buxton_set_conf_file"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+buxton_set_conf_file \- Set the path to the Buxton configuration file
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxton.h>
+\fR
+.sp
+\fB
+bool buxton_set_conf_file(char *\fIpath\fB)
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+Clients may use a custom Buxton configuration file, referenced by \fIpath\fR\&.
+The settings from the new configuration file take effect immediately\&.
+
+.SH "CODE EXAMPLE"
+.nf
+.sp
+#define _GNU_SOURCE
+#include <buxton.h>
+
+int main(void)
+{
+	BuxtonClient client;
+	int fd;
+
+	if ((fd = buxton_open(&client)) < 0) {
+		printf("couldn't connect\\n");
+		return -1;
+	}
+
+	if (!buxton_set_conf_file("/etc/buxton-custom.conf")) {
+		printf("failed to set conf file\\n");
+		return -1;
+	}
+
+	buxton_close(client);
+	return 0;
+}
+
+.fi
+
+.SH "RETURN VALUE"
+.PP
+Returns "true" on success, "false" on failure\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\&.conf\fR(5),
+\fBbuxton\fR(7),
+\fBbuxtond\fR(8),
+\fBbuxton\-api\fR(7)

--- a/docs/buxton_set_label.3
+++ b/docs/buxton_set_label.3
@@ -1,0 +1,143 @@
+'\" t
+.TH "BUXTON_SET_LABEL" "3" "buxton 1" "buxton_set_label"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+buxton_set_label \- Set the Smack label for a group or key
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxton.h>
+\fR
+.sp
+\fB
+bool buxton_set_label(BuxtonClient \fIclient\fB,
+.br
+                      BuxtonKey \fIkey\fB,
+.br
+                      char *\fIvalue\fB,
+.br
+                      BuxtonCallback \fIcallback\fB,
+.br
+                      void *\fIdata\fB,
+.br
+                      bool \fIsync\fB)
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+This function is used to set a Smack label, \fIvalue\fR, on a group
+or key, referred to by \fIkey\fR, on behalf of \fIclient\fR.
+
+Note that setting a Smack label is always a privileged operation, so
+this operation will fail for unprivileged clients\&.
+
+Both functions accept optional callback functions to register with
+the daemon, referenced by the \fIcallback\fR argument; the callback
+function is called upon completion of the operation\&. The \fIdata\fR
+argument is a pointer to arbitrary userdata that is passed along to
+the callback function\&. Additonally, the \fIsync\fR argument
+controls whether the operation should be synchronous or not; if
+\fIsync\fR is false, the operation is asynchronous\&.
+
+.SH "CODE EXAMPLE"
+.nf
+.sp
+#define _GNU_SOURCE
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "buxton.h"
+
+void set_label_cb(BuxtonResponse response, void *data)
+{
+	BuxtonKey key;
+	char *name;
+
+	if (buxton_response_status(response) != BUXTON_STATUS_OK) {
+		printf("Failed to set label\\n");
+		return;
+	}
+
+	key = buxton_response_key(response);
+	name = buxton_key_get_name(key);
+	printf("Set label for key %s\\n", name);
+	buxton_key_free(key);
+	free(name);
+}
+
+int main(void)
+{
+	BuxtonClient client;
+	BuxtonKey key;
+	struct pollfd pfd[1];
+	int r;
+	int fd;
+	char* label = "label-test";
+
+	if ((fd = buxton_open(&client)) < 0) {
+		printf("couldn't connect\\n");
+		return -1;
+	}
+
+	key = buxton_key_create("hello", "test", "user", INT32);
+	if (!key)
+		return -1;
+
+	if (!buxton_set_label(client, key, label, set_label_cb,
+				     NULL, false)) {
+		printf("set label call failed to run\\n");
+		return -1;
+	}
+
+	pfd[0].fd = fd;
+	pfd[0].events = POLLIN;
+	pfd[0].revents = 0;
+	r = poll(pfd, 1, 5000);
+
+	if (r <= 0) {
+		printf("poll error\\n");
+		return -1;
+	}
+
+	if (!buxton_client_handle_response(client)) {
+		printf("bad response from daemon\\n");
+		return -1;
+	}
+
+	buxton_key_free(key);
+	buxton_close(client);
+	return 0;
+}
+.fi
+
+.SH "RETURN VALUE"
+.PP
+Returns "true" on success, and "false" on failure\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7),
+\fBbuxtond\fR(8),
+\fBbuxton\-api\fR(7)

--- a/docs/buxton_set_value.3
+++ b/docs/buxton_set_value.3
@@ -1,0 +1,229 @@
+'\" t
+.TH "BUXTON_SET_VALUE" "3" "buxton 1" "buxton_set_value"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+buxton_set_value, buxton_unset_value \- Modify values for BuxtonKeys
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxton.h>
+\fR
+.sp
+\fB
+bool buxton_set_value(BuxtonClient \fIclient\fB,
+.br
+                      BuxtonKey \fIkey\fB,
+.br
+                      void *\fIvalue\fB,
+.br
+                      BuxtonCallback \fIcallback\fB,
+.br
+                      void *\fIdata\fB,
+.br
+                      bool \fIsync\fB)
+.sp
+.br
+bool buxton_unset_value(BuxtonClient \fIclient\fB,
+.br
+                        BuxtonKey \fIkey\fB,
+.br
+                        BuxtonCallback \fIcallback\fB,
+.br
+                        void *\fIdata\fB,
+.br
+                        bool \fIsync\fB)
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+These functions are used to modify values for a BuxtonKey, referenced
+by \fIkey\fR, on behalf of the \fIclient\fR.
+
+To set the value for a \fIkey\fR, clients should call
+\fBbuxton_set_value\fR(3), passing a pointer the \fIvalue\fR for the
+third argument\&.
+
+To unset the value for a \fIkey\fR, clients should call
+\fBbuxton_unset_value\fR(3)\&.
+
+Both functions accept optional callback functions to register with
+the daemon, referenced by the \fIcallback\fR argument; the callback
+function is called upon completion of the operation\&. The \fIdata\fR
+argument is a pointer to arbitrary userdata that is passed along to
+the callback function\&. Additonally, the \fIsync\fR argument
+controls whether the operation should be synchronous or not; if
+\fIsync\fR is false, the operation is asynchronous\&.
+
+.SH "CODE EXAMPLE"
+.PP
+An example for set_value:
+
+.nf
+.sp
+#define _GNU_SOURCE
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "buxton.h"
+
+void set_cb(BuxtonResponse response, void *data)
+{
+	BuxtonKey key;
+	char *name;
+
+	if (buxton_response_status(response) != BUXTON_STATUS_OK) {
+		printf("Failed to set value\\n");
+		return;
+	}
+
+	key = buxton_response_key(response);
+	name = buxton_key_get_name(key);
+	printf("Set value for key %s\\n", name);
+	buxton_key_free(key);
+	free(name);
+}
+
+int main(void)
+{
+	BuxtonClient client;
+	BuxtonKey key;
+	struct pollfd pfd[1];
+	int r;
+	int fd;
+	int32_t set;
+
+	if ((fd = buxton_open(&client)) < 0) {
+		printf("couldn't connect\\n");
+		return -1;
+	}
+
+	key = buxton_key_create("hello", "test", "user", INT32);
+	if (!key)
+		return -1;
+
+	set = 10;
+
+	if (!buxton_set_value(client, key, &set, set_cb,
+				     NULL, false)) {
+		printf("set call failed to run\\n");
+		return -1;
+	}
+
+	pfd[0].fd = fd;
+	pfd[0].events = POLLIN;
+	pfd[0].revents = 0;
+	r = poll(pfd, 1, 5000);
+
+	if (r <= 0) {
+		printf("poll error\\n");
+		return -1;
+	}
+
+	if (!buxton_client_handle_response(client)) {
+		printf("bad response from daemon\\n");
+		return -1;
+	}
+
+	buxton_key_free(key);
+	buxton_close(client);
+	return 0;
+}
+.fi
+
+.PP
+An example for unset_value:
+
+.nf
+.sp
+#define _GNU_SOURCE
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "buxton.h"
+
+void unset_cb(BuxtonResponse response, void *data)
+{
+	if (buxton_response_status(response) != BUXTON_STATUS_OK) {
+		printf("Failed to unset value\\n");
+	} else {
+		printf("Unset value\\n");
+	}
+}
+
+int main(void)
+{
+	BuxtonClient client;
+	BuxtonKey key;
+	struct pollfd pfd[1];
+	int r;
+	int fd;
+
+	if ((fd = buxton_open(&client)) < 0) {
+		printf("couldn't connect\\n");
+		return -1;
+	}
+
+	key = buxton_key_create("hello", "test", "user", INT32);
+	if (!key)
+		return -1;
+
+	if (!buxton_unset_value(client, key, unset_cb,
+					       NULL, false)) {
+		printf("unset call failed to run\\n");
+		return -1;
+	}
+
+	pfd[0].fd = fd;
+	pfd[0].events = POLLIN;
+	pfd[0].revents = 0;
+	r = poll(pfd, 1, 5000);
+
+	if (r <= 0) {
+		printf("poll error\\n");
+		return -1;
+	}
+
+	if (!buxton_client_handle_response(client)) {
+		printf("bad response from daemon\\n");
+		return -1;
+	}
+
+	buxton_key_free(key);
+	buxton_close(client);
+	return 0;
+}
+.fi
+
+.SH "RETURN VALUE"
+.PP
+Returns "true" on success, and "false" on failure\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7),
+\fBbuxtond\fR(8),
+\fBbuxton\-api\fR(7)

--- a/docs/buxton_unregister_notification.3
+++ b/docs/buxton_unregister_notification.3
@@ -1,0 +1,1 @@
+.so buxton_register_notification.3

--- a/docs/buxton_unset_value.3
+++ b/docs/buxton_unset_value.3
@@ -1,0 +1,1 @@
+.so buxton_set_value.3


### PR DESCRIPTION
This commit adds 10 man pages to cover all libbuxton API functions. There are 22 API functions in total, but many related functions redirect to a single page.

It is very much a work-in-progress, but I wanted to see if anyone has feedback on my approach, formatting, content, etc.

Items I'm concerned about:
- I haven't looked into how buxton_client_handle_response(3) works yet, so the information there is likely incorrect.
- I don't yet have a code example for buxton_unregister_notification(3), but I think William said that he would add a demo program that I can reuse.
