### PR TITLE
Fix double memory free in db_for_resource

### DIFF
--- a/src/db/gdbm.c
+++ b/src/db/gdbm.c
@@ -77,7 +77,6 @@ static GDBM_FILE db_for_resource(BuxtonLayer *layer)
 		if (!db) {
 			free(name);
 			buxton_log("Couldn't create db for path: %s\n", path);
-			free(path);
 			return 0;
 		}
 		r = hashmap_put(_resources, name, db);


### PR DESCRIPTION
Double free causes due _path_ auto variable already has cleanup attribute.
It's gcc specific, but such attribute uses in another places.

Signed-off-by: Alexey Perevalov a.perevalov@samsung.com
