### PR TITLE
serialize: fix align of the double type on ARM

### DIFF
--- a/src/cli/client.c
+++ b/src/cli/client.c
@@ -383,7 +383,7 @@ void get_value_callback(BuxtonResponse response, void *data)
 		r->type = FLOAT;
 		break;
 	case DOUBLE:
-		r->store.d_double = *(double *)p;
+		memcpy(&r->store.d_double, p, sizeof(double));
 		r->type = DOUBLE;
 		break;
 	case BOOLEAN:

--- a/src/shared/protocol.c
+++ b/src/shared/protocol.c
@@ -450,7 +450,7 @@ bool buxton_wire_set_value(_BuxtonClient *client, _BuxtonKey *key, void *value,
 		d_value.store.d_float = *(float *)value;
 		break;
 	case DOUBLE:
-		d_value.store.d_double = *(double *)value;
+		memcpy(&d_value.store.d_double, value, sizeof(double));
 		break;
 	case BOOLEAN:
 		d_value.store.d_boolean = *(bool *)value;

--- a/src/shared/serialize.c
+++ b/src/shared/serialize.c
@@ -172,7 +172,7 @@ void buxton_deserialize(uint8_t *source, BuxtonData *target,
 		target->store.d_float = *(float*)(source+offset);
 		break;
 	case DOUBLE:
-		target->store.d_double = *(double*)(source+offset);
+		memcpy(&target->store.d_double, source + offset, sizeof(double));
 		break;
 	case BOOLEAN:
 		target->store.d_boolean = *(bool*)(source+offset);
@@ -499,7 +499,7 @@ ssize_t buxton_deserialize_message(uint8_t *data,
 			c_data.store.d_float = *(float*)(data+offset);
 			break;
 		case DOUBLE:
-			c_data.store.d_double = *(double*)(data+offset);
+			memcpy(&c_data.store.d_double, data + offset, sizeof(double));
 			break;
 		case BOOLEAN:
 			c_data.store.d_boolean = *(bool*)(data+offset);


### PR DESCRIPTION
It's posible situation when gcc doesn't support malign-double command
line option. In this case copy operation on that platform could lead to SIGBUS
for type double.

buxton already uses memcpy for coping serialized data in serialize.c.

Signed-off-by: Alexey Perevalov a.perevalov@samsung.com
