### PR TITLE
cli: Ensure BuxtonClient is free'd for non-direct mode

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -309,7 +309,12 @@ int main(int argc, char **argv)
 end:
 	free(conf_path);
 	hashmap_free(commands);
-	buxton_direct_close(&control);
+	if (control.client.direct) {
+		buxton_direct_close(&control);
+	} else {
+		buxton_close(client);
+	}
+
 	if (ret) {
 		return EXIT_SUCCESS;
 	}


### PR DESCRIPTION
Prior to this commit, buxtonctl leaks 16 bytes on my local 64-bit machine.

==27429== 16 bytes in 1 blocks are definitely lost in loss record 1 of 5
==27429==    at 0x4C291D4: calloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==27429==    by 0x4E33136: buxton_open (lbuxton.c:104)
==27429==    by 0x4048A6: main (main.c:271)

I'm also a bit unhappy about hashmap still, will look at that in the near future.
