### PR TITLE
Cli fixes

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -101,7 +101,7 @@ int main(int argc, char **argv)
 	bool version = false;
 	control.client.direct = false;
 	char *conf_path = NULL;
-	BuxtonClient client;
+	BuxtonClient client = NULL;
 
 	/* libtool bites my twinkie */
 	include_configurator();
@@ -332,7 +332,9 @@ end:
 	if (control.client.direct) {
 		buxton_direct_close(&control);
 	} else {
-		buxton_close(client);
+		if (client) {
+			buxton_close(client);
+		}
 	}
 
 	if (ret) {


### PR DESCRIPTION
Previously we had a segfault on "buxtonctl" invocation with no arguments, I should've seen this but didn't. We now ensure we do free only an allocated BuxtonClient...
We also now support "-v,--version". 

Also, turns out if you use "--" getopt will stop parsing and you can pass a negative number to set-int32, etc.
