### PR TITLE
cli: Implement list_keys

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -92,6 +92,7 @@ int main(int argc, char **argv)
 	Command c_get_bool, c_set_bool;
 	Command c_set_label;
 	Command c_create_group, c_remove_group;
+	Command c_list_keys;
 	Command c_unset_value;
 	Command c_create_db;
 	Command *command;
@@ -200,6 +201,11 @@ int main(int argc, char **argv)
 	c_remove_group = (Command) { "remove-group", "Remove a group from a layer",
 				     2, 2, "layer group", &cli_remove_group, STRING };
 	hashmap_put(commands, c_remove_group.name, &c_remove_group);
+
+	/* List keys */
+	c_list_keys = (Command) { "list-keys", "List keys in a layer",
+				   1, 1, "layer", &cli_list_keys, STRING };
+	hashmap_put(commands, c_list_keys.name, &c_list_keys);
 
 	/* Unset value */
 	c_unset_value = (Command) { "unset-value", "Unset a value by key",

--- a/src/core/daemon.c
+++ b/src/core/daemon.c
@@ -114,7 +114,6 @@ bool parse_list(BuxtonControlMessage msg, size_t count, BuxtonData *list,
 		}
 		break;
 	case BUXTON_CONTROL_LIST:
-		return false;
 		if (count != 1) {
 			return false;
 		}

--- a/src/libbuxton/lbuxton.c
+++ b/src/libbuxton/lbuxton.c
@@ -33,6 +33,7 @@
 #include "buxton.h"
 #include "buxtonclient.h"
 #include "buxtonkey.h"
+#include "buxtonlist.h"
 #include "buxtonresponse.h"
 #include "buxtonstring.h"
 #include "configurator.h"
@@ -633,6 +634,17 @@ void *buxton_response_value(BuxtonResponse response)
 		if (r->data->len) {
 			d = buxton_array_get(r->data, 0);
 		}
+	} else if (type == BUXTON_CONTROL_LIST) {
+		BuxtonList *list = NULL;
+		BuxtonData *current = NULL;
+		for (uint16_t i = 1; i < r->data->len; i++) {
+			current = buxton_array_get(r->data, i);
+			/* Expose the BuxtonString only for now (name) */
+			if (!buxton_list_append(&list, &(current->store.d_string))) {
+				goto out;
+			}
+		}
+		return list;
 	} else {
 		goto out;
 	}

--- a/src/libbuxton/lbuxton.sym
+++ b/src/libbuxton/lbuxton.sym
@@ -9,6 +9,7 @@ BUXTON_1 {
 		buxton_remove_group;
 		buxton_get_value;
 		buxton_unset_value;
+		buxton_client_list_keys;
 		buxton_register_notification;
 		buxton_unregister_notification;
 		buxton_client_handle_response;


### PR DESCRIPTION
See commit message for gory details.
Note after this becomes merged we'll need to export BuxtonList (seems most appropriate for export instead of BuxtonArray) and for the public API part we should actually switch to using BuxtonKey's in our BuxtonList, not BuxtonStrings. Buxton buxton buxton. (Sorry, name is everywhere :P)

So, there is a method in place to re-extract the group name in gdbm, we're just missing the SMACK labels. I propose we modify the method to take the current smack label (via api, from buxtond, etc) to actually recreate a BuxtonKey listing. Seems way more appropriate (Also we can check then if they have the right label in the listing :))

Valgrinded in --direct and via wire, can't see any leaks
