### PR TITLE
build: make man page conditionally

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,6 +65,7 @@ pkgconfiglibdir=$(libdir)/pkgconfig
 pkgconfiglib_DATA = \
 	data/libbuxton.pc
 
+if MANPAGE
 dist_man_MANS = \
 	docs/buxton.7 \
 	docs/buxtonctl.1 \
@@ -95,6 +96,7 @@ dist_man_MANS = \
 	docs/buxton_set_value.3 \
 	docs/buxton_unregister_notification.3 \
 	docs/buxton_unset_value.3
+endif
 
 TESTS = \
 	check_db_clean \

--- a/configure.ac
+++ b/configure.ac
@@ -161,6 +161,13 @@ AS_IF([test "x$enable_debug" = "xyes"],
 	[AC_DEFINE([NDEBUG], [1], [Debugging and assertions disabled])])
 AM_CONDITIONAL([DEBUG], [test x$enable_debug = x"yes"])
 
+AC_ARG_ENABLE(manpages, AS_HELP_STRING([--enable-manpages], [enable man pages @<:@default=yes@:>@]),
+	      [], [enable_manpages=yes])
+AS_IF([test "x$enable_manpages" = "xyes"],
+	[AC_DEFINE([MANPAGE], [1], [Man pages will be included])],
+	[AC_DEFINE([NMANPAGE], [1], [Man pages will not be included])])
+AM_CONDITIONAL([MANPAGE], [test x$enable_manpages = x"yes"])
+
 have_coverage=no
 AC_ARG_ENABLE(coverage, AS_HELP_STRING([--enable-coverage], [enable test coverage]))
 if test "x$enable_coverage" = "xyes" ; then
@@ -232,4 +239,5 @@ AC_MSG_RESULT([
         debug:                  ${enable_debug}
         demos:                  ${enable_demos}
         coverage:               ${have_coverage}
+        manpages:               ${enable_manpages}
 ])


### PR DESCRIPTION
Some type of the environment may not use man pages at all.
For example devices for customer electronics.

Signed-off-by: Alexey Perevalov a.perevalov@samsung.com
