### PR TITLE
core: add read-only layer type

### DIFF
--- a/src/cli/client.c
+++ b/src/cli/client.c
@@ -327,6 +327,11 @@ bool cli_set_value(BuxtonControl *control, BuxtonDataType type,
 
 		printf("Failed to update key \'%s:%s\' in layer '%s'\n",
 		       nv(group), nv(name), nv(layer));
+		switch (ret)
+		{
+			case EROFS:
+				printf("Readonly layer!\n");
+		}
 		free(group);
 		free(name);
 		free(layer);

--- a/src/db/gdbm.c
+++ b/src/db/gdbm.c
@@ -47,6 +47,17 @@ static char *key_get_name(BuxtonString *key)
 	return c;
 }
 
+static GDBM_FILE try_open_database(char *path, const int oflag)
+{
+	GDBM_FILE db = gdbm_open(path, 0, oflag, 0600, NULL);
+	if (!db && (errno == EACCES || errno == EROFS))
+	{
+		db = gdbm_open(path, 0, GDBM_READER, 0600, NULL);
+	}
+
+	return db;
+}
+
 /* Open or create databases on the fly */
 static GDBM_FILE db_for_resource(BuxtonLayer *layer)
 {
@@ -54,6 +65,7 @@ static GDBM_FILE db_for_resource(BuxtonLayer *layer)
 	_cleanup_free_ char *path = NULL;
 	char *name = NULL;
 	int r;
+	int oflag = layer->readonly ? GDBM_READER : GDBM_WRCREAT;
 
 	assert(layer);
 	assert(_resources);
@@ -73,10 +85,10 @@ static GDBM_FILE db_for_resource(BuxtonLayer *layer)
 		if (!path) {
 			abort();
 		}
-		db = gdbm_open(path, 0, GDBM_WRCREAT, 0600, NULL);
+		db = try_open_database(path, oflag);
 		if (!db) {
-			free(name);
 			buxton_log("Couldn't create db for path: %s\n", path);
+			free(name);
 			return 0;
 		}
 		r = hashmap_put(_resources, name, db);
@@ -109,6 +121,9 @@ static int set_value(BuxtonLayer *layer, _BuxtonKey *key, BuxtonData *data,
 	assert(key);
 	assert(label);
 
+	if (layer->readonly)
+		return EPERM;
+
 	if (key->name.value) {
 		sz = key->group.length + key->name.length;
 		key_data.dptr = malloc(sz);
@@ -133,7 +148,7 @@ static int set_value(BuxtonLayer *layer, _BuxtonKey *key, BuxtonData *data,
 	}
 
 	db = db_for_resource(layer);
-	if (!db) {
+	if (!db || errno == EACCES || errno == EROFS) {
 		ret = ENOENT;
 		goto end;
 	}

--- a/src/shared/backend.c
+++ b/src/shared/backend.c
@@ -111,6 +111,12 @@ static BuxtonLayer *buxton_layer_new(ConfigLayer *conf_layer)
 		}
 	}
 
+	if (conf_layer->access && strcmp(conf_layer->access, "read-only") == 0) {
+		out->readonly = true;
+	} else {
+		out->readonly = false;
+	}
+
 	out->priority = conf_layer->priority;
 	return out;
 fail:

--- a/src/shared/backend.h
+++ b/src/shared/backend.h
@@ -61,6 +61,7 @@ typedef struct BuxtonLayer {
 	uid_t uid; /**<User ID for layers of type LAYER_USER */
 	int priority; /**<Priority of this layer */
 	char *description; /**<Description of this layer */
+	bool readonly;
 } BuxtonLayer;
 
 /**

--- a/src/shared/configurator.c
+++ b/src/shared/configurator.c
@@ -122,7 +122,7 @@ static inline char *_strdup(const char* string)
  * Something is really wrong and even if we could recover, the system
  * is not working correctly.
  */
-static char *get_ini_string(char *section, char *name)
+static char *get_ini_string(char *section, char *name, bool required)
 {
 	char buf[PATH_MAX];
 	char *s;
@@ -130,7 +130,7 @@ static char *get_ini_string(char *section, char *name)
 	assert(conf.ini);
 	snprintf(buf, sizeof(buf), "%s:%s", section, name);
 	s = iniparser_getstring(conf.ini, buf, NULL);
-	if (s == NULL) {
+	if (s == NULL && required) {
 		abort();
 	}
 	return s;
@@ -299,10 +299,11 @@ int buxton_key_get_layers(ConfigLayer **layers)
 			continue;
 		}
 		_layers[j].name = section_name;
-		_layers[j].description = get_ini_string(section_name, "Description");
-		_layers[j].backend = get_ini_string(section_name, "Backend");
-		_layers[j].type = get_ini_string(section_name, "Type");
+		_layers[j].description = get_ini_string(section_name, "Description", true);
+		_layers[j].backend = get_ini_string(section_name, "Backend", true);
+		_layers[j].type = get_ini_string(section_name, "Type", true);
 		_layers[j].priority = get_ini_int(section_name, "Priority");
+		_layers[j].access = get_ini_string(section_name, "Access", false);
 		j++;
 	}
 	*layers = _layers;

--- a/src/shared/configurator.h
+++ b/src/shared/configurator.h
@@ -40,6 +40,7 @@ typedef struct ConfigLayer {
 	char *type;
 	char *backend;
 	char *description;
+	char *access;
 	int priority;
 } ConfigLayer;
 

--- a/src/shared/direct.c
+++ b/src/shared/direct.c
@@ -393,6 +393,11 @@ bool buxton_direct_create_group(BuxtonControl *control,
 		goto fail;
 	}
 
+	if (layer->readonly) {
+		buxton_debug("Read-only layer!\n");
+		goto fail;
+	}
+
 	if (layer->type == LAYER_SYSTEM) {
 		char *root_check = getenv(BUXTON_ROOT_CHECK_ENV);
 		bool skip_check = (root_check && streq(root_check, "0"));
@@ -470,6 +475,11 @@ bool buxton_direct_remove_group(BuxtonControl *control,
 	config = &control->config;
 
 	if ((layer = hashmap_get(config->layers, key->layer.value)) == NULL) {
+		goto fail;
+	}
+
+	if (layer->readonly) {
+		buxton_debug("Read-ony layer!");
 		goto fail;
 	}
 


### PR DESCRIPTION
This patch introduce Access field for buxton's configuration. This field
isn't strictly required, instead of another field, so get_ini_string was extended
for this purpose.

Special mode for BuxtonLayer is implemented as readonly field, but not
bitmask.

Now only gdbm backend is
supported and only set_value use cases is covered.

Signed-off-by: Alexey Perevalov a.perevalov@samsung.com
