### PR TITLE
[RFC] daemon: try to read more when only message is remained

### DIFF
--- a/src/core/daemon.c
+++ b/src/core/daemon.c
@@ -1130,7 +1130,7 @@ bool handle_client(BuxtonDaemon *self, client_list_item *cl, nfds_t i)
 				abort();
 			}
 		}
-		if (cl->size != cl->offset) {
+		if (cl->size > cl->offset) {
 			continue;
 		}
 		if (!buxtond_handle_message(self, cl, cl->size)) {


### PR DESCRIPTION
I didn't test this yet but the loop continue condition some feel strange to me.

In last try of the loop, likely cl->size be smaller than cl->offset.
Without this patch, the loop will try to continue by below code, then cl->size - cl->offset will be overflow.
        if (cl->size != cl->offset) {
            continue;
        }
