### PR TITLE
Fixed bug in hashmap freeing that can cause a segfault

### DIFF
--- a/src/libbuxton/lbuxton.c
+++ b/src/libbuxton/lbuxton.c
@@ -125,6 +125,8 @@ void buxton_close(BuxtonClient client)
 
 	hashmap_free(key_hash);
 
+	key_hash = NULL;
+
 	if (!client) {
 		return;
 	}


### PR DESCRIPTION
When the client connection is closed, the hashmap is freed, but the
pointer to it was not set to null. Then when a new connection is made,
the key_hash pointer was checked if it points to null before trying
to access the hashmap. This caused a segfault when trying to
dereference the function pointer for the hash function, so it's now
being set to NULL to be able to test whether it was freed.
