### PR TITLE
Simplifying public Buxton API

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -63,7 +63,8 @@ LIBBUXTON_AGE=0
 
 pkgconfiglibdir=$(libdir)/pkgconfig
 pkgconfiglib_DATA = \
-	data/libbuxton.pc
+	data/libbuxton.pc \
+	data/libbuxtonsimple.pc
 
 if MANPAGE
 dist_man_MANS = \
@@ -95,7 +96,26 @@ dist_man_MANS = \
 	docs/buxton_set_label.3 \
 	docs/buxton_set_value.3 \
 	docs/buxton_unregister_notification.3 \
-	docs/buxton_unset_value.3
+	docs/buxton_unset_value.3 \
+	docs/buxtonsimple-api.7 \
+	docs/sbuxton_get_int32.3 \
+	docs/sbuxton_get_uint32.3 \
+	docs/sbuxton_get_string.3 \
+	docs/sbuxton_get_int64.3 \
+	docs/sbuxton_get_uint64.3 \
+	docs/sbuxton_get_float.3 \
+	docs/sbuxton_get_double.3 \
+	docs/sbuxton_get_bool.3 \
+	docs/sbuxton_set_int32.3 \
+	docs/sbuxton_set_uint32.3 \
+	docs/sbuxton_set_string.3 \
+	docs/sbuxton_set_int64.3 \
+	docs/sbuxton_set_uint64.3 \
+	docs/sbuxton_set_float.3 \
+	docs/sbuxton_set_double.3 \
+	docs/sbuxton_set_bool.3 \
+	docs/sbuxton_set_group.3 \
+	docs/sbuxton_remove_group.3 
 endif
 
 TESTS = \
@@ -104,7 +124,8 @@ TESTS = \
 	check_shared_lib \
 	check_daemon \
 	check_smack \
-	check_configurator
+	check_configurator \
+	check_buxtonsimple
 
 if COVERAGE
 coverage:
@@ -121,8 +142,10 @@ EXTRA_DIST = \
 	HACKING \
 	check_db_clean \
 	data/libbuxton.pc.in \
+	data/libbuxtonsimple.pc.in \
 	docs/LICENSE.MIT \
 	src/libbuxton/lbuxton.sym \
+	src/libbuxtonsimple/lbuxtonsimple.sym \
 	test/test.load2 \
 	test/test.conf \
 	test/test-configurator.conf
@@ -161,7 +184,8 @@ buxtonctl_LDADD = \
 	libbuxton-shared.la
 
 noinst_LTLIBRARIES += \
-	libbuxton-shared.la
+	libbuxton-shared.la \
+	libbuxtonsimple-shared.la
 
 libbuxton_shared_la_SOURCES = \
 	src/security/smack.c \
@@ -207,11 +231,22 @@ libbuxton_shared_la_LDFLAGS = \
 	$(AM_LDFLAGS) \
 	-static
 
+libbuxtonsimple_shared_la_SOURCES = \
+	src/shared/buxtonsimple-internals.h \
+	src/shared/buxtonsimple-internals.c
+
+libbuxtonsimple_shared_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	-static
+
 include_HEADERS += \
-	src/include/buxton.h
+	src/include/buxton.h \
+	src/include/buxtonsimple.h
+
 
 lib_LTLIBRARIES += \
-	libbuxton.la
+	libbuxton.la \
+	libbuxtonsimple.la 
 
 libbuxton_la_SOURCES = \
 	src/libbuxton/lbuxton.c
@@ -230,6 +265,24 @@ libbuxton_la_LDFLAGS = \
 libbuxton_la_LIBADD = \
 	libbuxton-shared.la \
 	-ldl
+
+
+libbuxtonsimple_la_SOURCES = \
+	src/libbuxtonsimple/lbuxtonsimple.c
+
+libbuxtonsimple_la_CFLAGS = \
+	$(AM_CFLAGS) \
+	-fvisibility=hidden
+
+libbuxtonsimple_la_LDFLAGS = \
+	-version-info 1:0:1 \
+	-version-info $(LIBBUXTON_CURRENT):$(LIBBUXTON_REVISION):$(LIBBUXTON_AGE) \
+	-Wl,--version-script=$(top_srcdir)/src/libbuxtonsimple/lbuxtonsimple.sym
+
+libbuxtonsimple_la_LIBADD = \
+	libbuxton.la \
+	libbuxton-shared.la \
+	libbuxtonsimple-shared.la 
 
 pkglib_LTLIBRARIES += \
 	gdbm.la \
@@ -262,7 +315,8 @@ check_PROGRAMS = \
 	check_buxtond \
 	check_daemon \
 	check_smack \
-	check_configurator
+	check_configurator \
+	check_buxtonsimple
 
 check_buxton_SOURCES = \
 	test/check_utils.c \
@@ -367,6 +421,23 @@ check_configurator_LDADD = \
 	@INIPARSER_LIBS@ \
 	libbuxton-shared.la
 
+check_buxtonsimple_SOURCES = \
+	test/check_buxtonsimple.c \
+	src/core/daemon.c \
+	src/core/daemon.h
+check_buxtonsimple_CFLAGS = \
+	$(AM_CFLAGS) \
+	@CHECK_CFLAGS@ \
+	-DMAKE_CHECK \
+	-DABS_TOP_SRCDIR=\"$(abs_top_srcdir)\" \
+	-DABS_TOP_BUILDDIR=\"$(abs_top_builddir)\"
+check_buxtonsimple_LDADD = \
+	@CHECK_LIBS@ \
+	libbuxtonsimple.la \
+	libbuxtonsimple-shared.la \
+	libbuxton.la \
+	libbuxton-shared.la
+
 check_DATA = \
 	test/test-pass.ini \
 	test/test-fail.ini \
@@ -384,7 +455,8 @@ bin_PROGRAMS += \
 	bxt_hello_remove_group \
 	bxt_hello_unset \
 	bxt_hello_notify \
-	bxt_hello_notify_multi
+	bxt_hello_notify_multi \
+	bxt_hello_simple
 
 # Timing test
 bxt_timing_SOURCES = \
@@ -449,6 +521,13 @@ bxt_hello_notify_multi_CFLAGS = \
 	$(AM_CFLAGS)
 bxt_hello_notify_multi_LDADD = \
 	libbuxton.la
+
+bxt_hello_simple_SOURCES = \
+	demo/hellosimple.c
+bxt_hello_simple_CFLAGS = \
+	$(AM_CFLAGS)
+bxt_hello_simple_LDADD = \
+	libbuxtonsimple.la
 
 if BUILD_GTK_DEMO
 bin_PROGRAMS += \

--- a/README
+++ b/README
@@ -7,10 +7,12 @@ arbitrary number of groups, each of which may contain key-value pairs.
 Mandatory Access Control (MAC) is implemented at the group level and at the
 key-value level.
 
-Buxton provides a C library (libbuxton) for client applications to use.
-Internally, buxton uses a daemon (buxtond) for processing client requests and
-enforcing MAC. Also, a CLI (buxtonctl) is provided for interactive use and for
-use in shell scripts.
+Buxton provides a C library (libbuxton) for client applications to use. As an
+alternative, it also provides a simpler C library (libbuxtonsimple) for client
+applications that reduces the amount of code needed to use buxton. Internally,
+buxton uses a daemon (buxtond) for processing client requests and enforcing MAC.
+Also, a CLI (buxtonctl) is provided for interactive use and for use in shell
+scripts.
 
 
 Build dependencies

--- a/configure.ac
+++ b/configure.ac
@@ -212,6 +212,7 @@ AC_CONFIG_FILES([
 data/buxton.service
 data/buxton.socket
 data/libbuxton.pc
+data/libbuxtonsimple.pc
 test/test-pass.ini
 test/test-fail.ini
 test/test.conf

--- a/data/libbuxtonsimple.pc.in
+++ b/data/libbuxtonsimple.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: buxton simple
+Description: Simple library for buxton clients
+URL: @PACKAGE_URL@
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lbuxtonsimple
+Cflags: -I${includedir}

--- a/demo/hellosimple.c
+++ b/demo/hellosimple.c
@@ -1,0 +1,187 @@
+/*
+ * This file is part of buxton.
+ *
+ * Copyright (C) 2014 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "buxtonsimple.h"
+
+/*DEMONSTRATION*/
+int main(void)
+{
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s0", "user");
+	printf("set_group: 'tg_s0', 'user', Error number: %s.\n", strerror(errno));
+
+	/*Test string setting*/
+	srand((unsigned)time(NULL));
+	char * s="Watermelon";
+	printf("value should be set to %s.\n", s);
+	errno = 0;
+	sbuxton_set_string("tk_s1", s);
+	printf("set_string: 'tg_s0', 'tk_s1', Error number: %s.\n", strerror(errno));
+
+	/*Test string getting*/
+	char * sv = sbuxton_get_string("tk_s1");
+	printf("Got value: %s(string).\n", sv);		
+	printf("get_string: 'tk_s1', Error number: %s.\n", strerror(errno));
+
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s1", "user");
+	printf("set_group: 'tg_s1', Error number: %s.\n", strerror(errno));
+
+	/*Test int32 setting*/
+	srand((unsigned)time(NULL));
+	int32_t i=rand() % 100 + 1;
+	printf("value should be set to %i.\n",i);
+	errno = 0;
+	sbuxton_set_int32("tk_i32", i);
+	printf("set_int32: 'tg_s1', 'tk_i32', Error number: %s.\n", strerror(errno));
+
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s2", "user");
+	printf("set_group: 'tg_s2', Error number: %s.\n", strerror(errno));
+
+	/*Test int32 setting*/
+	srand((unsigned)time(NULL));
+	int32_t i2=rand() % 1000 + 1;
+	printf("Second value should be set to %i.\n", i2);
+	errno = 0;
+	sbuxton_set_int32("tk_i32b", i2);
+	printf("set_int32: 'tg_s2', 'tk_i32b', Error number: %s.\n", strerror(errno));
+
+	/*Test int32 getting*/
+	/*Change group*/
+	errno = 0;
+	sbuxton_set_group("tg_s1", "user");
+	printf("set_group: 'tg_s1', Error number: %s.\n", strerror(errno));
+	errno = 0;
+	/*Get int32*/
+	int32_t iv = sbuxton_get_int32("tk_i32");
+	printf("get_int32: 'tg_s1', 'tk_i32', Error number: %s.\n", strerror(errno));
+	printf("Got value: %i(int32_t).\n", iv);
+	errno = 0;
+	/*Change group*/
+	sbuxton_set_group("tg_s2", "user");
+	printf("set_group: 'tg_s2', Error number: %s.\n", strerror(errno));
+	errno = 0;
+	/*Get int32*/
+	int32_t i2v = sbuxton_get_int32("tk_i32b");
+	printf("Got value: %i(int32_t).\n", i2v);
+	printf("get_int32: 'tg_s2', 'tk_i32b', Error number: %s.\n", strerror(errno));
+
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s3", "user");
+	printf("set_group: 'tg_s3', Error number: %s.\n", strerror(errno));
+
+	/*Test uint32 setting*/
+	uint32_t ui32 = (uint32_t) rand() % 50 + 1;
+	printf("value should be set to %u.\n", ui32);
+	errno = 0;
+	sbuxton_set_uint32("tk_ui32", ui32);
+	printf("set_uint32: 'tg_s3', 'tk_ui32', Error number: %s.\n", strerror(errno));
+	/*Test uint32 getting*/
+	errno = 0;
+	uint32_t ui32v = sbuxton_get_uint32("tk_ui32");
+	printf("Got value: %i(uint32_t).\n", ui32v);
+	printf("get_uint32: 'tg_s3', 'tk_ui32', Error number: %s.\n", strerror(errno));
+
+	/*Test  int64 setting*/
+	int64_t i64 = rand() % 1000 + 1;
+	printf("value should be set to ""%"PRId64".\n", i64);
+	errno = 0;
+	sbuxton_set_int64("tk_i64", i64);
+	/*Test int64 getting*/
+	errno = 0;
+	int64_t i64v = sbuxton_get_int64("tk_i64");
+	printf("Got value: ""%"PRId64"(int64_t).\n", i64v);
+	printf("get_int64: 'tg_s3', 'tk_i64', Error number: %s.\n", strerror(errno));
+
+	/*Change group*/
+	errno = 0;
+	sbuxton_set_group("tg_s0", "user");
+
+	/*Test uint64 setting*/
+	uint64_t ui64 = (uint64_t) rand() % 500 + 1;
+	printf("value should be set to ""%"PRIu64".\n", ui64);
+	errno = 0;
+	sbuxton_set_uint64("tk_ui64", ui64);
+	/*Test uint64 getting*/
+	errno = 0;
+	uint64_t ui64v = sbuxton_get_uint64("tk_ui64");
+	printf("Got value: ""%"PRIu64"(uint64_t).\n", ui64v);
+	printf("get_uint64: 'tg_s0', 'tk_ui64', Error number: %s.\n", strerror(errno));
+
+	/*Test float setting*/
+	float f = (float) (rand() % 9 + 1);
+	printf("value should be set to %e.\n", f);
+	errno = 0;
+	sbuxton_set_float("tk_f", f);
+	/*Test float getting*/
+	errno = 0;
+	float fv = sbuxton_get_float("tk_f");
+	printf("Got value: %e(float).\n", fv);
+	printf("get_float: 'tg_s0', 'tk_f', Error number: %s.\n", strerror(errno));
+
+	/*Test double setting*/
+	double d = rand() % 7000 + 1;
+	printf("value should be set to %e.\n", d);
+	errno = 0;
+	sbuxton_set_double("tk_d", d);
+	/*Test double getting*/
+	errno = 0;
+	double dv = sbuxton_get_double("tk_d");
+	printf("Got value: %e(double).\n", dv);
+	printf("get_double: 'tg_s0', 'tk_f', Error number: %s.\n", strerror(errno));
+
+	/*Test boolean setting*/
+	bool b = true;
+	printf("value should be set to %i.\n", b);
+	errno = 0;
+	sbuxton_set_bool("tk_b", b);
+	/*Test boolean getting*/
+	errno = 0;
+	bool bv = sbuxton_get_bool("tk_b");
+	printf("Got value: %i(bool).\n", bv);		
+	printf("get_bool: 'tg_s0', 'tk_b', Error number: %s.\n", strerror(errno));
+
+	/*Remove groups*/
+	errno = 0;
+	sbuxton_remove_group("tg_s1", "user");
+	sbuxton_remove_group("tg_s0", "user");
+	sbuxton_remove_group("tg_s2", "user");
+	sbuxton_remove_group("tg_s3", "user");
+
+	return 0;
+}

--- a/docs/buxtonsimple-api.7
+++ b/docs/buxtonsimple-api.7
@@ -1,0 +1,114 @@
+'\" t
+.TH "BUXTON\-SIMPLE\-API" "7" "" "buxton 1" "buxton\-simple\-api"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+buxton\-simple\-api \- List of all Buxton Simple API functions
+
+.SH "DESCRIPTION"
+.PP
+This document contains the complete list of Buxton Simple API functions,
+each having its own manual page\&.
+
+In addition, there are several "hello world" demo programs in the
+buxton source tree, in the demos/ directory, that demonstrate how to
+use these API functions\&.
+
+.SH "API functions"
+
+.SS "Group storage and manipulation"
+.PP
+\fBsbuxton_set_group\fR(3)
+\(em Create or change to a group within a layer
+.br
+\fBsbuxton_remove_group\fR(3)
+\(em Remove a group within a layer
+.br
+
+.SS "Key set functions"
+.PP
+\fBsbuxton_set_int32\fR(3)
+\(em Set the value for an int32_t type key
+.br
+\fBsbuxton_set_string\fR(3)
+\(em Set the value for a string type key
+.br
+\fBsbuxton_set_uint32\fR(3)
+\(em Set the value for a uint32_t type key
+.br
+\fBsbuxton_set_int64\fR(3)
+\(em Set the value for an int64_t type key
+.br
+\fBsbuxton_set_uint64\fR(3)
+\(em Set the value for a uint64_t type key
+.br
+\fBsbuxton_set_float\fR(3)
+\(em Set the value of a float type key
+.br
+\fBsbuxton_set_double\fR(3)
+\(em Set the value for a double type key
+.br
+\fBsbuxton_set_bool\fR(3)
+\(em Set the value for a bool type key
+.br
+
+.SS "Key get functions"
+.PP
+\fBsbuxton_get_int32\fR(3)
+\(em Get the value for an int32_t type key
+.br
+\fBsbuxton_get_string\fR(3)
+\(em Get the value for a string type key
+.br
+\fBsbuxton_get_uint32\fR(3)
+\(em Get the value for a uint32_t type key
+.br
+\fBsbuxton_get_int64\fR(3)
+\(em Get the value for an int64_t type key
+.br
+\fBsbuxton_get_uint64\fR(3)
+\(em Get the value for a uint64_t type key
+.br
+\fBsbuxton_get_float\fR(3)
+\(em Get the value of a float type key
+.br
+\fBsbuxton_get_double\fR(3)
+\(em Get the value for a double type key
+.br
+\fBsbuxton_get_bool\fR(3)
+\(em Get the value for a bool type key
+.br
+
+
+.SH "COPYRIGHT"
+.PP
+Copyright 2014 Intel Corporation\&. License: Creative Commons
+Attribution\-ShareAlike 3.0 Unported\s-2\u[1]\d\s+2\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7)
+
+.SH "NOTES"
+.IP " 1." 4
+Creative Commons Attribution\-ShareAlike 3.0 Unported
+.RS 4
+\%http://creativecommons.org/licenses/by-sa/3.0/
+.RE

--- a/docs/sbuxton_get_bool.3
+++ b/docs/sbuxton_get_bool.3
@@ -1,0 +1,1 @@
+.so sbuxton_get_int32.3

--- a/docs/sbuxton_get_double.3
+++ b/docs/sbuxton_get_double.3
@@ -1,0 +1,1 @@
+.so sbuxton_get_int32.3

--- a/docs/sbuxton_get_float.3
+++ b/docs/sbuxton_get_float.3
@@ -1,0 +1,1 @@
+.so sbuxton_get_int32.3

--- a/docs/sbuxton_get_int32.3
+++ b/docs/sbuxton_get_int32.3
@@ -1,0 +1,259 @@
+'\" t
+.TH "BUXTOND_GET" "3" "buxton 1" "sbuxton_get"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+sbuxton_get_string, sbuxton_get_int32, sbuxton_get_uint32, sbuxton_get_int64,
+sbuxton_get_uint64, sbuxton_get_float, sbuxton_get_double, sbuxton_get_bool
+\- Get the value of a typed key\-name
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxtonsimple.h>
+\fR
+.sp
+\fB
+char* sbuxton_get_string(char *\fIkey)
+.sp
+\fB
+int32_t sbuxton_get_int32(char *\fIkey)
+.sp
+\fB
+uint32_t sbuxton_get_uint32(char *\fIkey)
+.sp
+\fB
+int64_t sbuxton_get_int64(char *\fIkey)
+.sp
+\fB
+uint64_t sbuxton_get_uint64(char *\fIkey)
+.sp
+\fB
+float sbuxton_get_float(char *\fIkey)
+.sp
+\fB
+double sbuxton_get_double(char *\fIkey)
+.sp
+\fB
+bool sbuxton_get_bool(char *\fIkey)
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+These functions are used to get the value of a typed key\-name
+for the client program. E.g. sbuxton_get_int32 will return a value of type
+int32_t. The key\-name is referenced by \fIkey\fR,
+a string that corresponds to a key\-name in the current group and layer.
+
+If the function call fails, a message is printed to stderr, and errno is
+set to EACCES or ENOTCONN.
+
+.SH "CODE EXAMPLE"
+.nf
+.sp
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "buxtonsimple.h"
+
+/*DEMONSTRATION*/
+int main(void)
+{
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s0", "user");
+	printf("set_group: 'tg_s0', 'user', Error number: %s.\n", strerror(errno));
+
+	/*Test string setting*/
+	srand((unsigned)time(NULL));
+	char * s="Watermelon";
+	printf("value should be set to %s.\n", s);
+	errno = 0;
+	sbuxton_set_string("tk_s1", s);
+	printf("set_string: 'tg_s0', 'tk_s1', Error number: %s.\n", strerror(errno));
+
+	/*Test string getting*/
+	char * sv = sbuxton_get_string("tk_s1");
+	printf("Got value: %s(string).\n", sv);		
+	printf("get_string: 'tk_s1', Error number: %s.\n", strerror(errno));
+
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s1", "user");
+	printf("set_group: 'tg_s1', Error number: %s.\n", strerror(errno));
+
+	/*Test int32 setting*/
+	srand((unsigned)time(NULL));
+	int32_t i=rand()%100+1;
+	printf("value should be set to %i.\n",i);
+	errno = 0;
+	sbuxton_set_int32("tk_i32", i);
+	printf("set_int32: 'tg_s1', 'tk_i32', Error number: %s.\n", strerror(errno));
+
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s2", "user");
+	printf("set_group: 'tg_s2', Error number: %s.\n", strerror(errno));
+
+	/*Test int32 setting*/
+	srand((unsigned)time(NULL));
+	int32_t i2=rand()%1000+1;
+	printf("Second value should be set to %i.\n", i2);
+	errno = 0;
+	sbuxton_set_int32("tk_i32b", i2);
+	printf("set_int32: 'tg_s2', 'tk_i32b', Error number: %s.\n", strerror(errno));
+
+	/*Test int32 getting*/
+	/*Change group*/
+	errno = 0;
+	sbuxton_set_group("tg_s1", "user");
+	printf("set_group: 'tg_s1', Error number: %s.\n", strerror(errno));
+	errno = 0;
+	/*Get int32*/
+	int32_t iv = sbuxton_get_int32("tk_i32");
+	printf("get_int32: 'tg_s1', 'tk_i32', Error number: %s.\n", strerror(errno));
+	printf("Got value: %i(int32_t).\n", iv);
+	errno = 0;
+	/*Change group*/
+	sbuxton_set_group("tg_s2", "user");
+	printf("set_group: 'tg_s2', Error number: %s.\n", strerror(errno));
+	errno = 0;
+	/*Get int32*/
+	int32_t i2v = sbuxton_get_int32("tk_i32b");
+	printf("Got value: %i(int32_t).\n", i2v);
+	printf("get_int32: 'tg_s2', 'tk_i32b', Error number: %s.\n", strerror(errno));
+
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s3", "user");
+	printf("set_group: 'tg_s3', Error number: %s.\n", strerror(errno));
+
+	/*Test uint32 setting*/
+	uint32_t ui32 = (uint32_t) rand()%50+1;
+	printf("value should be set to %u.\n", ui32);
+	errno = 0;
+	sbuxton_set_uint32("tk_ui32", ui32);
+	printf("set_uint32: 'tg_s3', 'tk_ui32', Error number: %s.\n", strerror(errno));
+	/*Test uint32 getting*/
+	errno = 0;
+	uint32_t ui32v = sbuxton_get_uint32("tk_ui32");
+	printf("Got value: %i(uint32_t).\n", ui32v);
+	printf("get_uint32: 'tg_s3', 'tk_ui32', Error number: %s.\n", strerror(errno));
+
+	/*Test  int64 setting*/
+	int64_t i64 = rand()%1000+1;
+	printf("value should be set to ""%"PRId64".\n", i64);
+	errno = 0;
+	sbuxton_set_int64("tk_i64", i64);
+	/*Test int64 getting*/
+	errno = 0;
+	int64_t i64v = sbuxton_get_int64("tk_i64");
+	printf("Got value: ""%"PRId64"(int64_t).\n", i64v);
+	printf("get_int64: 'tg_s3', 'tk_i64', Error number: %s.\n", strerror(errno));
+
+	/*Change group*/
+	errno = 0;
+	sbuxton_set_group("tg_s0", "user");
+
+	/*Test uint64 setting*/
+	uint64_t ui64 = (uint64_t) rand()%500+1;
+	printf("value should be set to ""%"PRIu64".\n", ui64);
+	errno = 0;
+	sbuxton_set_uint64("tk_ui64", ui64);
+	/*Test uint64 getting*/
+	errno = 0;
+	uint64_t ui64v = sbuxton_get_uint64("tk_ui64");
+	printf("Got value: ""%"PRIu64"(uint64_t).\n", ui64v);
+	printf("get_uint64: 'tg_s0', 'tk_ui64', Error number: %s.\n", strerror(errno));
+
+	/*Test float setting*/
+	float f = (float) (rand()%9+1);
+	printf("value should be set to %e.\n", f);
+	errno = 0;
+	sbuxton_set_float("tk_f", f);
+	/*Test float getting*/
+	errno = 0;
+	float fv = sbuxton_get_float("tk_f");
+	printf("Got value: %e(float).\n", fv);
+	printf("get_float: 'tg_s0', 'tk_f', Error number: %s.\n", strerror(errno));
+
+	/*Test double setting*/
+	double d = rand()%7000+1;
+	printf("value should be set to %e.\n", d);
+	errno = 0;
+	sbuxton_set_double("tk_d", d);
+	/*Test double getting*/
+	errno = 0;
+	double dv = sbuxton_get_double("tk_d");
+	printf("Got value: %e(double).\n", dv);
+	printf("get_double: 'tg_s0', 'tk_f', Error number: %s.\n", strerror(errno));
+
+	/*Test boolean setting*/
+	bool b = true;
+	printf("value should be set to %i.\n", b);
+	errno = 0;
+	sbuxton_set_bool("tk_b", b);
+	/*Test boolean getting*/
+	errno = 0;
+	bool bv = sbuxton_get_bool("tk_b");
+	printf("Got value: %i(bool).\n", bv);		
+	printf("get_bool: 'tg_s0', 'tk_b', Error number: %s.\n", strerror(errno));
+
+	/*Remove groups*/
+	errno = 0;
+	sbuxton_remove_group("tg_s1", "user");
+	sbuxton_remove_group("tg_s0", "user");
+	sbuxton_remove_group("tg_s2", "user");
+	sbuxton_remove_group("tg_s3", "user");
+
+	return 0;
+}
+.fi
+
+.SH "RETURN VALUE"
+.PP
+Returns the value of the key on success\&. On failure, errno is set to ENOTCONN
+if the client couldn't connect and EACCES otherwise.
+
+.SH "COPYRIGHT"
+.PP
+Copyright 2014 Intel Corporation\&. License: Creative Commons
+Attribution\-ShareAlike 3.0 Unported\s-2\u[1]\d\s+2, with exception
+for code examples found in the \fBCODE EXAMPLE\fR section, which are
+licensed under the MIT license provided in the \fIdocs/LICENSE.MIT\fR
+file from this buxton distribution\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7),
+\fBbuxtond\fR(8),
+\fBbuxtonsimple\-api\fR(7)
+
+.SH "NOTES"
+.IP " 1." 4
+Creative Commons Attribution\-ShareAlike 3.0 Unported
+.RS 4
+\%http://creativecommons.org/licenses/by-sa/3.0/
+.RE

--- a/docs/sbuxton_get_int64.3
+++ b/docs/sbuxton_get_int64.3
@@ -1,0 +1,1 @@
+.so sbuxton_get_int32.3

--- a/docs/sbuxton_get_string.3
+++ b/docs/sbuxton_get_string.3
@@ -1,0 +1,1 @@
+.so sbuxton_get_int32.3

--- a/docs/sbuxton_get_uint32.3
+++ b/docs/sbuxton_get_uint32.3
@@ -1,0 +1,1 @@
+.so sbuxton_get_int32.3

--- a/docs/sbuxton_get_uint64.3
+++ b/docs/sbuxton_get_uint64.3
@@ -1,0 +1,1 @@
+.so sbuxton_get_int32.3

--- a/docs/sbuxton_remove_group.3
+++ b/docs/sbuxton_remove_group.3
@@ -1,0 +1,1 @@
+.so sbuxton_set_group.3

--- a/docs/sbuxton_set_bool.3
+++ b/docs/sbuxton_set_bool.3
@@ -1,0 +1,1 @@
+.so sbuxton_set_int32.3

--- a/docs/sbuxton_set_double.3
+++ b/docs/sbuxton_set_double.3
@@ -1,0 +1,1 @@
+.so sbuxton_set_int32.3

--- a/docs/sbuxton_set_float.3
+++ b/docs/sbuxton_set_float.3
@@ -1,0 +1,1 @@
+.so sbuxton_set_int32.3

--- a/docs/sbuxton_set_group.3
+++ b/docs/sbuxton_set_group.3
@@ -1,0 +1,260 @@
+'\" t
+.TH "BUXTOND_SET_GROUP" "3" "buxton 1" "sbuxton_set_group"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+sbuxton_set_group, sbuxton_remove_group
+.sp
+\- Manage groups within buxton
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxtonsimple.h>
+\fR
+.sp
+\fB
+void sbuxton_set_group(char *\fIgroup\fB,
+.br
+                        char *\fIlayer\fB);
+.br
+.sp
+.br
+void sbuxton_remove_group(char *\fIgroup_name\fB,
+.br
+                        char *\fIlayer\fB);
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+These functions are used for managing groups within buxton\&.
+
+Before a value can be set for a key-name, the group for the key-name
+must be created\&. A group can be created or switched to by calling
+\fBsbuxton_set_group\fR(3). The group is created if it does
+not already exist, or switched to if a group with that name and layer already
+exists. Then all following key function calls (e.g. \fBsbuxton_set_int32\fR(3)
+or \fBsbuxton_get_float\fR(3)) 
+refer to keys in this group\&.
+For more information about key manipulation, see
+\fBsbuxton_set_int32\fR(3) and \fBsbuxton_get_int32\fR(3)\&.
+
+Groups can also be removed by calling \fBsbuxton_remove_group\fR(3)\&.
+Note that this operation is recursive, removing all key-names within
+a group, and the group itself\&.
+
+.SH "CODE EXAMPLE"
+.PP
+An example for \fBsbuxton_set_group\fR(3):
+
+.nf
+.sp
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "buxtonsimple.h"
+
+/*DEMONSTRATION*/
+int main(void)
+{
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s0", "user");
+	printf("set_group: 'tg_s0', 'user', Error number: %s.\n", strerror(errno));
+
+	/*Test string setting*/
+	srand((unsigned)time(NULL));
+	char * s="Watermelon";
+	printf("value should be set to %s.\n", s);
+	errno = 0;
+	sbuxton_set_string("tk_s1", s);
+	printf("set_string: 'tg_s0', 'tk_s1', Error number: %s.\n", strerror(errno));
+
+	/*Test string getting*/
+	char * sv = sbuxton_get_string("tk_s1");
+	printf("Got value: %s(string).\n", sv);		
+	printf("get_string: 'tk_s1', Error number: %s.\n", strerror(errno));
+
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s1", "user");
+	printf("set_group: 'tg_s1', Error number: %s.\n", strerror(errno));
+
+	/*Test int32 setting*/
+	srand((unsigned)time(NULL));
+	int32_t i=rand()%100+1;
+	printf("value should be set to %i.\n",i);
+	errno = 0;
+	sbuxton_set_int32("tk_i32", i);
+	printf("set_int32: 'tg_s1', 'tk_i32', Error number: %s.\n", strerror(errno));
+
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s2", "user");
+	printf("set_group: 'tg_s2', Error number: %s.\n", strerror(errno));
+
+	/*Test int32 setting*/
+	srand((unsigned)time(NULL));
+	int32_t i2=rand()%1000+1;
+	printf("Second value should be set to %i.\n", i2);
+	errno = 0;
+	sbuxton_set_int32("tk_i32b", i2);
+	printf("set_int32: 'tg_s2', 'tk_i32b', Error number: %s.\n", strerror(errno));
+
+	/*Test int32 getting*/
+	/*Change group*/
+	errno = 0;
+	sbuxton_set_group("tg_s1", "user");
+	printf("set_group: 'tg_s1', Error number: %s.\n", strerror(errno));
+	errno = 0;
+	/*Get int32*/
+	int32_t iv = sbuxton_get_int32("tk_i32");
+	printf("get_int32: 'tg_s1', 'tk_i32', Error number: %s.\n", strerror(errno));
+	printf("Got value: %i(int32_t).\n", iv);
+	errno = 0;
+	/*Change group*/
+	sbuxton_set_group("tg_s2", "user");
+	printf("set_group: 'tg_s2', Error number: %s.\n", strerror(errno));
+	errno = 0;
+	/*Get int32*/
+	int32_t i2v = sbuxton_get_int32("tk_i32b");
+	printf("Got value: %i(int32_t).\n", i2v);
+	printf("get_int32: 'tg_s2', 'tk_i32b', Error number: %s.\n", strerror(errno));
+
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s3", "user");
+	printf("set_group: 'tg_s3', Error number: %s.\n", strerror(errno));
+
+	/*Test uint32 setting*/
+	uint32_t ui32 = (uint32_t) rand()%50+1;
+	printf("value should be set to %u.\n", ui32);
+	errno = 0;
+	sbuxton_set_uint32("tk_ui32", ui32);
+	printf("set_uint32: 'tg_s3', 'tk_ui32', Error number: %s.\n", strerror(errno));
+	/*Test uint32 getting*/
+	errno = 0;
+	uint32_t ui32v = sbuxton_get_uint32("tk_ui32");
+	printf("Got value: %i(uint32_t).\n", ui32v);
+	printf("get_uint32: 'tg_s3', 'tk_ui32', Error number: %s.\n", strerror(errno));
+
+	/*Test  int64 setting*/
+	int64_t i64 = rand()%1000+1;
+	printf("value should be set to ""%"PRId64".\n", i64);
+	errno = 0;
+	sbuxton_set_int64("tk_i64", i64);
+	/*Test int64 getting*/
+	errno = 0;
+	int64_t i64v = sbuxton_get_int64("tk_i64");
+	printf("Got value: ""%"PRId64"(int64_t).\n", i64v);
+	printf("get_int64: 'tg_s3', 'tk_i64', Error number: %s.\n", strerror(errno));
+
+	/*Change group*/
+	errno = 0;
+	sbuxton_set_group("tg_s0", "user");
+
+	/*Test uint64 setting*/
+	uint64_t ui64 = (uint64_t) rand()%500+1;
+	printf("value should be set to ""%"PRIu64".\n", ui64);
+	errno = 0;
+	sbuxton_set_uint64("tk_ui64", ui64);
+	/*Test uint64 getting*/
+	errno = 0;
+	uint64_t ui64v = sbuxton_get_uint64("tk_ui64");
+	printf("Got value: ""%"PRIu64"(uint64_t).\n", ui64v);
+	printf("get_uint64: 'tg_s0', 'tk_ui64', Error number: %s.\n", strerror(errno));
+
+	/*Test float setting*/
+	float f = (float) (rand()%9+1);
+	printf("value should be set to %e.\n", f);
+	errno = 0;
+	sbuxton_set_float("tk_f", f);
+	/*Test float getting*/
+	errno = 0;
+	float fv = sbuxton_get_float("tk_f");
+	printf("Got value: %e(float).\n", fv);
+	printf("get_float: 'tg_s0', 'tk_f', Error number: %s.\n", strerror(errno));
+
+	/*Test double setting*/
+	double d = rand()%7000+1;
+	printf("value should be set to %e.\n", d);
+	errno = 0;
+	sbuxton_set_double("tk_d", d);
+	/*Test double getting*/
+	errno = 0;
+	double dv = sbuxton_get_double("tk_d");
+	printf("Got value: %e(double).\n", dv);
+	printf("get_double: 'tg_s0', 'tk_f', Error number: %s.\n", strerror(errno));
+
+	/*Test boolean setting*/
+	bool b = true;
+	printf("value should be set to %i.\n", b);
+	errno = 0;
+	sbuxton_set_bool("tk_b", b);
+	/*Test boolean getting*/
+	errno = 0;
+	bool bv = sbuxton_get_bool("tk_b");
+	printf("Got value: %i(bool).\n", bv);		
+	printf("get_bool: 'tg_s0', 'tk_b', Error number: %s.\n", strerror(errno));
+
+	/*Remove groups*/
+	errno = 0;
+	sbuxton_remove_group("tg_s1", "user");
+	sbuxton_remove_group("tg_s0", "user");
+	sbuxton_remove_group("tg_s2", "user");
+	sbuxton_remove_group("tg_s3", "user");
+
+	return 0;
+}
+.fi
+
+.SH "RETURN VALUE"
+.PP
+Returns void\&. Prints to buxton_debug on failure and success\&. On failure, sets
+errno to ENOTCONN if client couldn't connect and sets errno to EBADMSG otherwise.
+Note that EBADMSG could mean that the group was not created because it already
+exists.
+
+.SH "COPYRIGHT"
+.PP
+Copyright 2014 Intel Corporation\&. License: Creative Commons
+Attribution\-ShareAlike 3.0 Unported\s-2\u[1]\d\s+2, with exception
+for code examples found in the \fBCODE EXAMPLE\fR section, which are
+licensed under the MIT license provided in the \fIdocs/LICENSE.MIT\fR
+file from this buxton distribution\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7),
+\fBbuxtond\fR(8),
+\fBbuxton\-simp\-api\fR(7)
+
+.SH "NOTES"
+.IP " 1." 4
+Creative Commons Attribution\-ShareAlike 3.0 Unported
+.RS 4
+\%http://creativecommons.org/licenses/by-sa/3.0/
+.RE

--- a/docs/sbuxton_set_int32.3
+++ b/docs/sbuxton_set_int32.3
@@ -1,0 +1,259 @@
+'\" t
+.TH "BUXTOND_SET" "3" "buxton 1" "sbuxton_set"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+sbuxton_set_string, sbuxton_set_int32, sbuxton_set_uint32, sbuxton_set_int64, 
+sbuxton_set_uint64, sbuxton_set_float, sbuxton_set_double, sbuxton_set_bool
+\- Modify values for BuxtonKeys
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxtonsimple.h>
+\fR
+.sp
+\fB
+void sbuxton_set_string(char *\fIkey\fB, char *\fIvalue\fB);
+.sp
+\fB
+void sbuxton_set_int32(char *\fIkey\fB, int32_t \fIvalue\fB);
+.sp
+\fB
+void sbuxton_set_uint32(char *\fIkey\fB, uint32_t \fIvalue\fB);
+.sp
+\fB
+void sbuxton_set_int64(char *\fIkey\fB, int64_t \fIvalue\fB);
+.sp
+\fB
+void sbuxton_set_uint64(char *\fIkey\fB, uint64_t \fIvalue\fB);
+.sp
+\fB
+void sbuxton_set_float(char *\fIkey\fB, float \fIvalue\fB);
+.sp
+\fB
+void sbuxton_set_double(char *\fIkey\fB, double \fIvalue\fB);
+.sp
+\fB
+void sbuxton_set_bool(char *\fIkey\fB, bool \fIvalue\fB);
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+These functions are used to set the value of a typed key\-name
+for the client program. E.g. sbuxton_set_int32 will set a value of type
+int32_t. The key\-name is referenced by \fIkey\fR,
+a string that corresponds to a key\-name in the current group and layer.
+
+If the function call fails, a message is printed to stderr, and errno is
+set to EACCES or ENOTCONN.
+
+.SH "CODE EXAMPLE"
+.nf
+.sp
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "buxtonsimple.h"
+
+/*DEMONSTRATION*/
+int main(void)
+{
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s0", "user");
+	printf("set_group: 'tg_s0', 'user', Error number: %s.\n", strerror(errno));
+
+	/*Test string setting*/
+	srand((unsigned)time(NULL));
+	char * s="Watermelon";
+	printf("value should be set to %s.\n", s);
+	errno = 0;
+	sbuxton_set_string("tk_s1", s);
+	printf("set_string: 'tg_s0', 'tk_s1', Error number: %s.\n", strerror(errno));
+
+	/*Test string getting*/
+	char * sv = sbuxton_get_string("tk_s1");
+	printf("Got value: %s(string).\n", sv);		
+	printf("get_string: 'tk_s1', Error number: %s.\n", strerror(errno));
+
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s1", "user");
+	printf("set_group: 'tg_s1', Error number: %s.\n", strerror(errno));
+
+	/*Test int32 setting*/
+	srand((unsigned)time(NULL));
+	int32_t i=rand()%100+1;
+	printf("value should be set to %i.\n",i);
+	errno = 0;
+	sbuxton_set_int32("tk_i32", i);
+	printf("set_int32: 'tg_s1', 'tk_i32', Error number: %s.\n", strerror(errno));
+
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s2", "user");
+	printf("set_group: 'tg_s2', Error number: %s.\n", strerror(errno));
+
+	/*Test int32 setting*/
+	srand((unsigned)time(NULL));
+	int32_t i2=rand()%1000+1;
+	printf("Second value should be set to %i.\n", i2);
+	errno = 0;
+	sbuxton_set_int32("tk_i32b", i2);
+	printf("set_int32: 'tg_s2', 'tk_i32b', Error number: %s.\n", strerror(errno));
+
+	/*Test int32 getting*/
+	/*Change group*/
+	errno = 0;
+	sbuxton_set_group("tg_s1", "user");
+	printf("set_group: 'tg_s1', Error number: %s.\n", strerror(errno));
+	errno = 0;
+	/*Get int32*/
+	int32_t iv = sbuxton_get_int32("tk_i32");
+	printf("get_int32: 'tg_s1', 'tk_i32', Error number: %s.\n", strerror(errno));
+	printf("Got value: %i(int32_t).\n", iv);
+	errno = 0;
+	/*Change group*/
+	sbuxton_set_group("tg_s2", "user");
+	printf("set_group: 'tg_s2', Error number: %s.\n", strerror(errno));
+	errno = 0;
+	/*Get int32*/
+	int32_t i2v = sbuxton_get_int32("tk_i32b");
+	printf("Got value: %i(int32_t).\n", i2v);
+	printf("get_int32: 'tg_s2', 'tk_i32b', Error number: %s.\n", strerror(errno));
+
+	/*Create group*/
+	errno = 0;
+	sbuxton_set_group("tg_s3", "user");
+	printf("set_group: 'tg_s3', Error number: %s.\n", strerror(errno));
+
+	/*Test uint32 setting*/
+	uint32_t ui32 = (uint32_t) rand()%50+1;
+	printf("value should be set to %u.\n", ui32);
+	errno = 0;
+	sbuxton_set_uint32("tk_ui32", ui32);
+	printf("set_uint32: 'tg_s3', 'tk_ui32', Error number: %s.\n", strerror(errno));
+	/*Test uint32 getting*/
+	errno = 0;
+	uint32_t ui32v = sbuxton_get_uint32("tk_ui32");
+	printf("Got value: %i(uint32_t).\n", ui32v);
+	printf("get_uint32: 'tg_s3', 'tk_ui32', Error number: %s.\n", strerror(errno));
+
+	/*Test  int64 setting*/
+	int64_t i64 = rand()%1000+1;
+	printf("value should be set to ""%"PRId64".\n", i64);
+	errno = 0;
+	sbuxton_set_int64("tk_i64", i64);
+	/*Test int64 getting*/
+	errno = 0;
+	int64_t i64v = sbuxton_get_int64("tk_i64");
+	printf("Got value: ""%"PRId64"(int64_t).\n", i64v);
+	printf("get_int64: 'tg_s3', 'tk_i64', Error number: %s.\n", strerror(errno));
+
+	/*Change group*/
+	errno = 0;
+	sbuxton_set_group("tg_s0", "user");
+
+	/*Test uint64 setting*/
+	uint64_t ui64 = (uint64_t) rand()%500+1;
+	printf("value should be set to ""%"PRIu64".\n", ui64);
+	errno = 0;
+	sbuxton_set_uint64("tk_ui64", ui64);
+	/*Test uint64 getting*/
+	errno = 0;
+	uint64_t ui64v = sbuxton_get_uint64("tk_ui64");
+	printf("Got value: ""%"PRIu64"(uint64_t).\n", ui64v);
+	printf("get_uint64: 'tg_s0', 'tk_ui64', Error number: %s.\n", strerror(errno));
+
+	/*Test float setting*/
+	float f = (float) (rand()%9+1);
+	printf("value should be set to %e.\n", f);
+	errno = 0;
+	sbuxton_set_float("tk_f", f);
+	/*Test float getting*/
+	errno = 0;
+	float fv = sbuxton_get_float("tk_f");
+	printf("Got value: %e(float).\n", fv);
+	printf("get_float: 'tg_s0', 'tk_f', Error number: %s.\n", strerror(errno));
+
+	/*Test double setting*/
+	double d = rand()%7000+1;
+	printf("value should be set to %e.\n", d);
+	errno = 0;
+	sbuxton_set_double("tk_d", d);
+	/*Test double getting*/
+	errno = 0;
+	double dv = sbuxton_get_double("tk_d");
+	printf("Got value: %e(double).\n", dv);
+	printf("get_double: 'tg_s0', 'tk_f', Error number: %s.\n", strerror(errno));
+
+	/*Test boolean setting*/
+	bool b = true;
+	printf("value should be set to %i.\n", b);
+	errno = 0;
+	sbuxton_set_bool("tk_b", b);
+	/*Test boolean getting*/
+	errno = 0;
+	bool bv = sbuxton_get_bool("tk_b");
+	printf("Got value: %i(bool).\n", bv);		
+	printf("get_bool: 'tg_s0', 'tk_b', Error number: %s.\n", strerror(errno));
+
+	/*Remove groups*/
+	errno = 0;
+	sbuxton_remove_group("tg_s1", "user");
+	sbuxton_remove_group("tg_s0", "user");
+	sbuxton_remove_group("tg_s2", "user");
+	sbuxton_remove_group("tg_s3", "user");
+
+	return 0;
+}
+.fi
+
+.SH "RETURN VALUE"
+.PP
+Returns void\&. On failure, errno is set to ENOTCONN if the client couldn't
+connect and EACCES otherwise.
+
+.SH "COPYRIGHT"
+.PP
+Copyright 2014 Intel Corporation\&. License: Creative Commons
+Attribution\-ShareAlike 3.0 Unported\s-2\u[1]\d\s+2, with exception
+for code examples found in the \fBCODE EXAMPLE\fR section, which are
+licensed under the MIT license provided in the \fIdocs/LICENSE.MIT\fR
+file from this buxton distribution\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7),
+\fBbuxtonsimple\-api\fR(7),
+\fBbuxtond\fR(8)
+
+.SH "NOTES"
+.IP " 1." 4
+Creative Commons Attribution\-ShareAlike 3.0 Unported
+.RS 4
+\%http://creativecommons.org/licenses/by-sa/3.0/
+.RE

--- a/docs/sbuxton_set_int64.3
+++ b/docs/sbuxton_set_int64.3
@@ -1,0 +1,1 @@
+.so sbuxton_set_int32.3

--- a/docs/sbuxton_set_string.3
+++ b/docs/sbuxton_set_string.3
@@ -1,0 +1,1 @@
+.so sbuxton_set_int32.3

--- a/docs/sbuxton_set_uint32.3
+++ b/docs/sbuxton_set_uint32.3
@@ -1,0 +1,1 @@
+.so sbuxton_set_int32.3

--- a/docs/sbuxton_set_uint64.3
+++ b/docs/sbuxton_set_uint64.3
@@ -1,0 +1,1 @@
+.so sbuxton_set_int32.3

--- a/src/include/buxtonsimple.h
+++ b/src/include/buxtonsimple.h
@@ -1,0 +1,144 @@
+/*
+ * This file is part of buxton.
+ *
+ * Copyright (C) 2014 Intel Corporation
+ *
+ * Buxton is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the license, or (at your option) any later version.
+ */
+
+/**
+ * \file buxtonsimple.h Buxton public header
+ *
+ *
+ * \copyright Copyright (C) 2014 Intel corporation
+ * \par License
+ * GNU Lesser General Public License 2.1
+ */
+
+#include "buxton.h"
+#ifdef HAVE_CONFIG_H
+	#include "config.h"
+#endif
+
+#if (__GNUC__ >= 4)
+/* Export symbols */
+#    define _bx_export_ __attribute__ ((visibility("default")))
+#else
+#  define _bx_export_
+#endif
+
+
+/*Buxton Simple API Methods*/
+/**
+ * Creates a group if it does not exist and uses that group for all following get and set calls
+ * If the group already exists, it will be used for all following get and set calls
+ * Group and layer names longer than 256 bits will be truncated
+ * @param group A group name that is a string (char *)
+ * @param layer A layer name that is a string (char *)
+ */
+_bx_export_ void sbuxton_set_group(char *group, char *layer);
+/** 
+ * Buxton set int32_t sets an int32_t value for a given key
+ * @param key A key name that is a string (char *)
+ * @param value A 32-bit integer value
+ */
+_bx_export_ void sbuxton_set_int32(char *key, int32_t value);
+/** 
+ * Buxton get int32_t gets an int32_t value from a given key
+ * @param key A key name that is a string (char *)
+ * @return A 32-bit integer value
+ */
+_bx_export_ int32_t sbuxton_get_int32(char *key);
+/** 
+ * Buxton set string sets a string (char *) value for a given key
+ * @param key A key name that is a string (char *)
+ * @param value A string (char *) value
+ */
+_bx_export_ void sbuxton_set_string(char *key, char *value );
+/** 
+ * Buxton get string gets a string (char *) value from a given key
+ * @param key A key name that is a string (char *)
+ * @return A string (char *) value
+ */
+_bx_export_ char* sbuxton_get_string(char *key);
+/** 
+ * Buxton set uint32_t sets a uint32_t value for a given key
+ * @param key A key name that is a string (char *)
+ * @param value A 32-bit unsigned integer value
+ */
+_bx_export_ void sbuxton_set_uint32(char *key, uint32_t value);
+/** 
+ * Buxton get uint32_t gets an uint32_t value from a given key
+ * @param key A key name that is a string (char *)
+ * @return A 32-bit unsigned integer value
+ */
+_bx_export_ uint32_t sbuxton_get_uint32(char *key);
+/** 
+ * Buxton set int64_t sets an int64_t value for a given key
+ * @param key A key name that is a string (char *)
+ * @param value A 64-bit integer value
+ */
+_bx_export_ void sbuxton_set_int64(char *key, int64_t value);
+/** 
+ * Buxton get int64_t gets an int64_t value from a given key
+ * @param key A key name that is a string (char *)
+ * @return A 64-bit integer value
+ */
+_bx_export_ int64_t sbuxton_get_int64(char *key);
+/** 
+ * Buxton set uint64_t sets a uint64_t value for a given key
+ * @param key A key name that is a string (char *)
+ * @param value A 64-bit unsigned integer value
+ */
+_bx_export_ void sbuxton_set_uint64(char *key, uint64_t value);
+/** 
+ * Buxton get uint64_t gets a uint64_t value from a given key
+ * @param key A key name that is a string (char *)
+ * @return A 64-bit unsigned integer value
+ */
+_bx_export_ uint64_t sbuxton_get_uint64(char *key);
+/** 
+ * Buxton set float sets a floating point value for a given key
+ * @param key A key name that is a string (char *)
+ * @param value A floating point value
+ */
+_bx_export_ void sbuxton_set_float(char *key, float value);
+/** 
+ * Buxton get float gets a floating point value from a given key
+ * @param key A key name that is a string (char *)
+ * @return A floating point value
+ */
+_bx_export_ float sbuxton_get_float(char *key);
+/** 
+ * Buxton set double sets a double value for a given key
+ * @param key A key name that is a string (char *)
+ * @param value A double value
+ */
+_bx_export_ void sbuxton_set_double(char *key, double value);
+/** 
+ * Buxton get double gets a double value from a given key
+ * @param key A key name that is a string (char *)
+ * @return A double value
+ */
+_bx_export_ double sbuxton_get_double(char *key);
+/** 
+ * Buxton set bool sets a boolean value for a given key
+ * @param key A key name that is a string (char *)
+ * @param value A boolean value
+ */
+_bx_export_ void sbuxton_set_bool(char *key, bool value);
+/** 
+ * Buxton get bool gets a boolean value from a given key
+ * @param key A key name that is a string (char *)
+ * @return A boolean value
+ */
+_bx_export_ bool sbuxton_get_bool(char *key);
+/**
+ * Removes a group and clears all of the key value pairs in that group
+ * @param group_name A group name that is a string (char *)
+ * @param layer A layer name that is a string (char *)
+ */
+_bx_export_ void sbuxton_remove_group(char *group_name, char *layer);

--- a/src/libbuxtonsimple/lbuxtonsimple.c
+++ b/src/libbuxtonsimple/lbuxtonsimple.c
@@ -1,0 +1,514 @@
+/*
+ * This file is part of buxton.
+ *
+ * Copyright (C) 2014 Intel Corporation
+ *
+ * buxton is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the license, or (at your option) any later version.
+ */
+ 
+ /**
+ * \file lbuxtonsimple.c Buxton library implementation
+ */
+ 
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "buxtonsimple.h"
+#include "buxtonsimple-internals.h"
+#include "log.h"
+/* Max length of layer and group names  */
+#define MAX_LG_LEN 256
+
+extern BuxtonClient client;
+static char _layer[MAX_LG_LEN];
+static char _group[MAX_LG_LEN];
+static int saved_errno;
+
+/* Initialization of group */
+void sbuxton_set_group(char *group, char *layer)
+{
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return;
+	}
+	saved_errno = errno;
+	int status = 0;
+	/* strcpy the name of the layer and group*/
+	strncpy(_layer, layer, MAX_LG_LEN-1);
+	strncpy(_group, group, MAX_LG_LEN-1);
+	/* In case a string is longer than MAX_LG_LEN, set the last byte to null */
+	_layer[MAX_LG_LEN -1] = '\0';
+	_group[MAX_LG_LEN -1] = '\0';
+	BuxtonKey g = buxton_key_create(_group, NULL, _layer, STRING);
+	buxton_debug("buxton key group = %s\n", buxton_key_get_group(g));
+	if (buxton_create_group(client, g, _cg_cb, &status, true)
+		|| !status) {
+		buxton_debug("Create group call failed.\n");
+		errno = EBADMSG;
+	} else {
+		buxton_debug("Switched to group: %s, layer: %s.\n", buxton_key_get_group(g),
+ 	buxton_key_get_layer(g));
+		errno = saved_errno;
+	}
+	_client_disconnect();
+}
+
+/* Set and get int32_t value for buxton key with type INT32 */
+void sbuxton_set_int32(char *key, int32_t value)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return;
+	}
+	/* create key  */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, INT32);
+	/* return value and status */
+	vstatus ret;
+	ret.type = INT32;
+	ret.val.i32val = value;
+	saved_errno = errno;
+	/* call buxton_set_value for type INT32 */
+	if (buxton_set_value(client, _key, &value, _bs_cb, &ret, true)) {
+		buxton_debug("Set int32_t call failed.\n");
+		return;
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+}
+
+int32_t sbuxton_get_int32(char *key)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return -1;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, INT32);
+	/* return value */
+	vstatus ret;
+	ret.type = INT32;
+	saved_errno = errno;
+	/* get value */
+	if (buxton_get_value(client, _key, _bg_cb, &ret, true)) {
+		buxton_debug("Get int32_t call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+	return ret.val.i32val;
+}
+
+/* Set and get char * value for buxton key with type STRING */
+void sbuxton_set_string(char *key, char *value )
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, STRING);
+	/* return value and status */
+	vstatus ret;
+	ret.type = STRING;
+	ret.val.sval = value;
+	saved_errno = errno;
+	/* set value */
+	if (buxton_set_value(client, _key, &value, _bs_cb, &ret, true)) {
+		buxton_debug("Set string call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+}
+
+char* sbuxton_get_string(char *key)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return NULL;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, STRING);
+	/* return value */
+	vstatus ret;
+	ret.type = STRING;
+	saved_errno = errno;
+	/* get value */
+	if (buxton_get_value(client, _key, _bg_cb, &ret, true)) {
+		buxton_debug("Get string call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+	return ret.val.sval;
+}
+
+/* Set and get uint32_t value for buxton key with type UINT32 */
+void sbuxton_set_uint32(char *key, uint32_t value)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, UINT32);
+	/* return value and status */
+	vstatus ret;
+	ret.type = UINT32;
+	ret.val.ui32val = value;
+	saved_errno = errno;
+	if (buxton_set_value(client,_key, &value, _bs_cb, &ret, true)) {
+		buxton_debug("Set uint32_t call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+}
+
+uint32_t sbuxton_get_uint32(char *key)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return 0;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, UINT32);
+	/* return value */
+	vstatus ret;
+	ret.type = UINT32;
+	saved_errno = errno;
+	/* get value */
+	if (buxton_get_value(client, _key, _bg_cb, &ret, true)) {
+		buxton_debug("Get uint32_t call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+	return ret.val.ui32val;
+}
+
+/* Set and get int64_t value for buxton key with type INT64 */
+void sbuxton_set_int64(char *key, int64_t value)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, INT64);
+	/* return value and status */
+	vstatus ret;
+	ret.type = INT64;
+	ret.val.i64val = value;
+	saved_errno = errno;
+	if (buxton_set_value(client, _key, &value, _bs_cb, &ret, true)) {
+		buxton_debug("Set int64_t call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+}
+
+int64_t sbuxton_get_int64(char *key)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return -1;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, INT64);
+	/* return value */
+	vstatus ret;
+	ret.type = INT64;
+	saved_errno = errno;
+	/* get value */
+	if (buxton_get_value(client, _key, _bg_cb, &ret, true)) {
+		buxton_debug("Get int64_t call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+	return ret.val.i64val;
+}
+
+/* Set and get uint64_t value for buxton key with type UINT64 */
+void sbuxton_set_uint64(char *key, uint64_t value)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, UINT64);
+	/* return value and status */
+	vstatus ret;
+	ret.type = UINT64;
+	ret.val.ui64val = value;
+	saved_errno = errno;
+	if (buxton_set_value(client, _key, &value, _bs_cb, &ret, true)) {
+		buxton_debug("Set uint64_t call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+}
+
+uint64_t sbuxton_get_uint64(char *key)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return 0;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, UINT64);
+	/* return value */
+	vstatus ret;
+	ret.type = UINT64;
+	saved_errno = errno;
+	/* get value */
+	if (buxton_get_value(client, _key, _bg_cb, &ret, true)) {
+		buxton_debug("Get uint64_t call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+	return ret.val.ui64val;
+}
+
+/* Set and get float value for buxton key with type FLOAT */
+void sbuxton_set_float(char *key, float value)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, FLOAT);
+	/* return value and status */
+	vstatus ret;
+	ret.type = FLOAT;
+	ret.val.fval = value;
+	saved_errno = errno;
+	if (buxton_set_value(client, _key, &value, _bs_cb, &ret, true)) {
+		buxton_debug("Set float call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+}
+
+float sbuxton_get_float(char *key)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return -1;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, FLOAT);
+	/* return value */
+	vstatus ret;
+	ret.type = FLOAT;
+	saved_errno = errno;
+	/* get value */
+	if (buxton_get_value(client, _key, _bg_cb, &ret, true)) {
+		buxton_debug("Get float call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+	return ret.val.fval;
+}
+
+/* Set and get double value for buxton key with type DOUBLE */
+void sbuxton_set_double(char *key, double value)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, DOUBLE);
+	/* return value and status */
+	vstatus ret;
+	ret.type = DOUBLE;
+	ret.val.dval = value;
+	saved_errno = errno;
+	if (buxton_set_value(client, _key, &value, _bs_cb, &ret, true)) {
+		buxton_debug("Set double call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+}
+
+double sbuxton_get_double(char *key)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return -1;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, DOUBLE);
+	/* return value */
+	vstatus ret;
+	ret.type = DOUBLE;
+	saved_errno = errno;
+	/* get value */
+	if (buxton_get_value(client, _key, _bg_cb, &ret, true)) {
+		buxton_debug("Get double call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+	return ret.val.dval;
+}
+
+/* Set and get bool value for buxton key with type BOOLEAN */
+void sbuxton_set_bool(char *key, bool value)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, BOOLEAN);
+	/* return value and status */
+	vstatus ret;
+	ret.type = BOOLEAN;
+	ret.val.bval = value;
+	saved_errno = errno;
+	if (buxton_set_value(client, _key, &value, _bs_cb, &ret, true)) {
+		buxton_debug("Set bool call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+}
+
+bool sbuxton_get_bool(char *key)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return false;
+	}
+	/* create key */
+	BuxtonKey _key = buxton_key_create(_group, key, _layer, BOOLEAN);
+	/* return value */
+	vstatus ret;
+	ret.type = BOOLEAN;
+	saved_errno = errno;
+	/* get value */
+	if (buxton_get_value(client, _key, _bg_cb, &ret, true)) {
+		buxton_debug("Get bool call failed.\n");
+	}
+	if (!ret.status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+	return ret.val.bval;
+}
+
+/* Remove group given its name and layer */
+void sbuxton_remove_group(char *group_name, char *layer)
+{
+	/* make sure client connection is open */
+	if (!_client_connection()) {
+		errno = ENOTCONN;
+		return;
+	}
+	saved_errno = errno;
+	BuxtonKey group = _buxton_group_create(group_name, layer);
+	int status;
+	if (buxton_remove_group(client, group, _rg_cb, &status, true)) {
+		buxton_debug("Remove group call failed.\n");
+	}
+	if (!status) {
+		errno = EACCES;
+	} else {
+		errno = saved_errno;
+	}
+	_client_disconnect();
+}
+
+/*
+ * Editor modelines  -	http://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: t
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 noexpandtab:
+ * :indentSize=8:tabSize=8:noTabs=false:
+ */

--- a/src/libbuxtonsimple/lbuxtonsimple.sym
+++ b/src/libbuxtonsimple/lbuxtonsimple.sym
@@ -1,0 +1,23 @@
+BUXTONSIMPLE_1 {
+	global:
+		sbuxton_set_group;
+		sbuxton_set_int32;
+		sbuxton_get_int32;
+		sbuxton_set_string;
+		sbuxton_get_string;
+		sbuxton_set_uint32;
+		sbuxton_get_uint32;
+		sbuxton_set_int64;
+		sbuxton_get_int64;
+		sbuxton_set_uint64;
+		sbuxton_get_uint64;
+		sbuxton_set_float;
+		sbuxton_get_float;
+		sbuxton_set_double;
+		sbuxton_get_double;
+		sbuxton_set_bool;
+		sbuxton_get_bool;
+		sbuxton_remove_group;
+	local:
+		*;
+};

--- a/src/shared/buxtonsimple-internals.c
+++ b/src/shared/buxtonsimple-internals.c
@@ -1,0 +1,247 @@
+/*
+ * This file is part of buxton.
+ *
+ * Copyright (C) 2014 Intel Corporation
+ *
+ * buxton is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the license, or (at your option) any later version.
+ */
+ 
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "buxton.h"
+#include "buxtonsimple-internals.h"
+#include "log.h"
+
+BuxtonClient client = NULL;
+
+/* Make sure client connection is open */
+int _client_connection(void)
+{
+	/* Check if client connection is open */
+	if (!client) {
+		/* Open connection if needed */
+		if ((buxton_open(&client)) <0 ) {
+			buxton_debug("Couldn't connect.\n");
+			return 0;
+		}	
+		buxton_debug("Connection successful.\n");
+	}
+	return 1;
+}
+
+/* Close an open client connection */
+void _client_disconnect(void)
+{
+	/* Only attempt to close the client if it != NULL */
+	if (client) {
+		/* Close the connection */
+		buxton_close(client);
+		buxton_debug("Connection closed\n");
+		client = NULL;
+	}
+}
+
+/* Create group callback */
+void _cg_cb(BuxtonResponse response, void *data)
+{
+	int *status = (int *)data;
+	*status = 0;
+	if (buxton_response_status(response) != 0) {
+		buxton_debug("Failed to create group (may already exist).\n");
+	} else {
+		buxton_debug("Created group.\n");
+		*status = 1;
+	}
+}
+
+/* Debug message for setting buxton key values */
+void _bs_print(vstatus *data, BuxtonResponse response)
+{
+	switch (data->type) {
+		case STRING:
+		{
+			char *val = data->val.sval;
+			buxton_debug("Success: value has been set: %s(string). ", val);
+			break;
+		}
+		case INT32:
+		{
+			int32_t val = data->val.i32val;
+			buxton_debug("Success: value has been set: %d(int32_t). ", val);
+			break;
+		}
+		case UINT32:
+		{
+			uint32_t val = data->val.ui32val;
+			buxton_debug("Success: value has been set: %d(uint32_t). ", val);
+			break;
+		}
+		case INT64:
+		{
+			int64_t val = data->val.i64val;
+			buxton_debug("Success: value has been set: ""%"PRId64"(int64_t). ", val);
+			break;
+		}
+		case UINT64:
+		{
+			uint64_t val = data->val.ui64val;
+			buxton_debug("Success: value has been set: ""%"PRIu64"(uint64_t). ", val);
+			break;
+		}
+		case FLOAT:
+		{
+			float val = data->val.fval;
+			buxton_debug("Success: value has been set: %f(float). ", val);
+			break;
+		}
+		case DOUBLE:
+		{
+			double val = data->val.dval;
+			buxton_debug("Success: value has been set: %e(double). ", val);
+			break;
+		}
+		case BOOLEAN:
+		{
+			bool val = data->val.bval;
+			buxton_debug("Success: value has been set: %i(bool). ", val);
+			break;
+		}
+		default:
+		{
+			buxton_debug("Data type not found\n");
+			break;
+		}
+	}
+	BuxtonKey k = buxton_response_key(response);
+	buxton_debug("Key: %s, Group: %s, Layer: %s.\n", buxton_key_get_name(k), buxton_key_get_group(k), buxton_key_get_layer(k));
+	buxton_key_free(k);	
+}
+
+/* buxton_set_value callback for all buxton data types */
+void _bs_cb(BuxtonResponse response, void *data){
+	vstatus *ret = (vstatus*)data;
+	ret->status = 0;
+	/* check response before switch */
+	if (buxton_response_status(response)) {
+		buxton_debug("Failed to set value.\n");
+		return;
+	}
+	ret->status = 1;
+	_bs_print(ret, response);
+
+}
+
+/* buxton_get_value callback for all buxton data types */
+void _bg_cb(BuxtonResponse response, void *data)
+{
+	char *type;
+	vstatus *ret = (vstatus *)data;
+	ret->status = 0;
+	if (buxton_response_status(response)) {
+		buxton_debug("Failed to get value. \n");
+		return;
+	}
+	void *p = buxton_response_value(response);
+	if (!p) {
+		buxton_debug("Null response value.\n");
+		return;
+	}
+	switch (ret->type) {
+		case STRING:
+		{
+			ret->val.sval = *(char**)p;
+			type = "string";
+			break;
+		}
+		case INT32:
+		{
+			ret->val.i32val = *(int32_t*)p;
+			type = "int32_t";
+			break;
+		}
+		case UINT32:
+		{
+			ret->val.ui32val = *(uint32_t*)p;
+			type = "uint32_t";
+			break;
+		}
+		case INT64:
+		{
+			ret->val.i64val = *(int64_t*)p;
+			type = "int64_t";
+			break;
+		}
+		case UINT64:
+		{
+			ret->val.ui64val = *(uint64_t*)p;
+			type = "uint64_t";
+			break;
+		}
+		case FLOAT:
+		{
+			ret->val.fval = *(float*)p;
+			type = "float";
+			break;
+		}
+		case DOUBLE:
+		{
+			ret->val.dval = *(double*)p;
+			type = "double";
+			break;
+		}
+		case BOOLEAN:
+		{
+			ret->val.bval = *(bool*)p;
+			type = "bool";
+			break;
+		}
+		default:
+		{
+			type = "unknown";
+			break;
+		}
+	}
+	buxton_debug("Got %s value.\n", type);
+	ret->status = 1;
+}
+
+/* create a client side group TODO: create BuxtonGroup type probably not really needed */
+BuxtonKey _buxton_group_create(char *name, char *layer)
+{
+	BuxtonKey ret = buxton_key_create(name, NULL, layer, STRING);
+	return ret;
+}
+
+/* buxton_remove_group callback and function */
+void _rg_cb(BuxtonResponse response, void *data)
+{
+	int *ret = (int *)data;
+	*ret = 0;
+	if (buxton_response_status(response) != 0) {
+		buxton_debug("Failed to remove group.\n");
+	} else {
+		*ret = 1;
+		buxton_debug("Removed group.\n");
+	}
+}
+
+/*
+ * Editor modelines  -	http://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: t
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 noexpandtab:
+ * :indentSize=8:tabSize=8:noTabs=false:
+ */
+
+

--- a/src/shared/buxtonsimple-internals.h
+++ b/src/shared/buxtonsimple-internals.h
@@ -1,0 +1,147 @@
+/*
+ * This file is part of buxton.
+ *
+ * Copyright (C) 2014 Intel Corporation
+ *
+ * Buxton is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the license, or (at your option) any later version.
+ */
+
+/**
+ * \file buxtonsimple.h Buxton public header
+ *
+ *
+ * \copyright Copyright (C) 2014 Intel corporation
+ * \par License
+ * GNU Lesser General Public License 2.1
+ */
+
+#include "buxton.h"
+#ifdef HAVE_CONFIG_H
+	#include "config.h"
+#endif
+
+#if (__GNUC__ >= 4)
+/* Export symbols */
+#    define _bx_export_ __attribute__ ((visibility("default")))
+#else
+#  define _bx_export_
+#endif
+
+#pragma once
+
+/**
+ * @struct vstatus
+ * @brief Structure with possible data types for key values and status for buxton_response_status
+ * For setting a value, the caller stores the value to be set and the BuxtonDataType before callback
+ * For getting a value, the caller stores the BuxtonDataType before callback
+ * The buxton get callback puts the value that should be returned into the structure
+ * The buxton set callback accesses the structure for the value to be set and prints it(in debug mode)
+ * status is used to check for success or failure of an operation
+ * status is set to 0 on failure and 1 on success(set when checking buxton_response_status)
+ * @var vstatus::status
+ * Member 'status' contains a boolean value to indicate whether an operation failed or succeeded
+ * @var vstatus::type
+ * Member 'type' contains a BuxtonDataType that holds the type of value being set or gotten
+ * @var vstatus::sval
+ * Member 'sval' a string that contains the value for (set) or from (get) a STRING key
+ * @var vstatus::i32val
+ * Member 'i32val' a 32-bit integer that contains the value for or from an INT32 key
+ * @var vstatus::ui32val
+ * Member 'ui32val' an unsigned 32-bit integer that contains the value for or from a UINT32 key
+ * @var vstatus::i64val
+ * Member 'i64val' a 64-bit integer that contains the value for or from an INT64 key
+ * @var vstatus::ui64val
+ * Member 'ui64val' an unsigned 64-bit integer that contains the value for or from a UINT64 key
+ * @var vstatus::fval
+ * Member 'fval' a floating point that contains the value for or from a FLOAT key
+ * @var vstatus::dval
+ * Member 'dval' a double that contains the value for or from a DOUBLE key
+ * @var vstatus::bval
+ * Member 'bval' a boolean that contains the value for or from a BOOLEAN key
+ */
+typedef struct vstatus {
+	int status;
+	BuxtonDataType type;
+	union {
+		char *sval;
+		int32_t i32val;
+		uint32_t ui32val;
+		int64_t i64val;
+		uint64_t ui64val;
+		float fval;
+		double dval;
+		bool bval;
+	} val;
+} vstatus;
+
+extern BuxtonClient client;
+
+/**
+ * Checks for client connection and opens it if client connection is not open
+ * @return Returns 1 on success and 0 on failure
+ */
+int _client_connection(void);
+
+/**
+ * Checks for client connections and closes it if client connection is open
+ */
+void _client_disconnect(void);
+
+/**
+ * Create group callback
+ * @param response BuxtonResponse
+ * @param data A void pointer that points to data passed in by buxton_create_group
+ */
+void _cg_cb(BuxtonResponse response, void *data);
+
+/**
+ * Prints the value that has been set along with the key name, group, and layer (when in debug mode)
+ * @param data Pointer to structure with the value to be set, its type, and a status to be set on success
+ * @param response A BuxtonResponse used to get and print the key name, group, and layer  
+ */
+void _bs_print(vstatus *data, BuxtonResponse response);
+
+/** 
+ * Buxton set value callback checks buxton_response_status and calls bs_print
+ * @param response A BuxtonResponse that is used to see if value has been set properly  
+ * @param data A void pointer to a vstatus structure with status that will be set
+ */
+void _bs_cb(BuxtonResponse response, void *data);
+
+/**
+ * Buxton get value callback
+ * @param response A BuxtonResponse used to get the value and check status (buxton_response_status)
+ * @param data A void pointer to a vstatus structure with status and value that will be set
+ */
+void _bg_cb(BuxtonResponse response, void *data);
+
+/**
+ * Creates a BuxtonKey internally for buxtond_remove_group to remove
+ * @param name A group name that is a string (char *)
+ * @param layer A layer name that is a string (char *)
+ * @return A BuxtonKey that is a group
+ */
+BuxtonKey _buxton_group_create(char *name, char *layer);
+
+/**
+ * Remove group callback
+ * @param response A BuxtonResponse
+ * @param data A void pointer
+ */
+void _rg_cb(BuxtonResponse response, void *data);
+
+/*
+ * Editor modelines  -	http://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: t
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 noexpandtab:
+ * :indentSize=8:tabSize=8:noTabs=false:
+ */

--- a/test/check_buxtonsimple.c
+++ b/test/check_buxtonsimple.c
@@ -1,0 +1,547 @@
+/*
+ * This file is part of buxton.
+ *
+ * Copyright (C) 2014 Intel Corporation
+ *
+ * buxton is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#ifdef HAVE_CONFIG_H
+	#include "config.h"
+#endif
+
+#include <check.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "buxton.h"
+#include "buxtonresponse.h"
+#include "buxtonsimple.h"
+#include "buxtonsimple-internals.h"
+#include "configurator.h"
+#include "util.h"
+#ifdef NDEBUG
+#error "re-run configure with --enable-debug"
+#endif
+
+#define BUXTON_ROOT_CHECK_ENV "BUXTON_ROOT_CHECK"
+
+/* for forking the daemon in setup */
+static pid_t daemon_pid;
+
+/* setup and teardown functions */
+static void exec_daemon(void)
+{
+	char path[PATH_MAX];
+
+	//FIXME: path is wrong for makedistcheck
+	snprintf(path, PATH_MAX, "%s/buxtond", get_current_dir_name());
+
+	if (execl(path, "buxtond", (const char*)NULL) < 0) {
+		fail("couldn't exec: %m");
+	}
+	fail("should never reach here");
+}
+
+static void setup(void)
+{
+	daemon_pid = 0;
+	sigset_t sigset;
+	pid_t pid;
+
+	unlink(buxton_socket());
+
+	//TODO: find out what sigset is
+	sigemptyset(&sigset);
+	sigaddset(&sigset, SIGCHLD);
+	sigprocmask(SIG_BLOCK, &sigset, NULL);
+
+	pid = fork();
+	fail_if(pid < 0, "couldn't fork");
+	if (pid) {
+		/* parent*/
+		daemon_pid = pid;
+		usleep(128*1000);
+	} else {
+		/* child */
+		exec_daemon();
+	}
+}
+
+static void teardown(void)
+{
+	if (daemon_pid) {
+		int status;
+		pid_t pid;
+
+		pid = waitpid(daemon_pid, &status, WNOHANG);
+		fail_if(pid == -1, "waitpid error");
+		if (pid) {
+			fail("daemon crashed!");
+		} else	{
+			/* if the daemon is still running, kill it */
+			kill(SIGTERM, daemon_pid);
+			usleep(64*1000);
+			kill(SIGKILL, daemon_pid);
+		}
+	}
+}
+
+/* start libbuxtonsimple test */
+START_TEST (sbuxton_set_group_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EBADMSG, "Set group failed");
+}
+END_TEST
+
+START_TEST (sbuxton_set_int32_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	int32_t int32_val = 5;
+	errno = 0;
+	sbuxton_set_int32("int32key", int32_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set int32 failed");
+}
+END_TEST
+
+START_TEST (sbuxton_get_int32_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	int32_t int32_val = 5;
+	errno = 0;
+	sbuxton_set_int32("int32key", int32_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set int32 failed");
+	errno = 0;
+	int32_t ret = sbuxton_get_int32("int32key");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Get int32 failed");
+	fail_if(ret != int32_val, "Get int32 returned wrong value");
+}
+END_TEST
+
+START_TEST (sbuxton_set_string_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	char *string_val = "Testing...";
+	errno = 0;
+	sbuxton_set_string("stringkey", string_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set string failed");
+}
+END_TEST
+
+START_TEST (sbuxton_get_string_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	char *string_val = "Testing...";
+	errno = 0;
+	sbuxton_set_string("stringkey", string_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set string failed");
+	errno = 0;
+	char* ret = sbuxton_get_string("stringkey");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Get string failed");
+	fail_if(strcmp(ret, string_val), "Get string returned wrong value");
+}
+END_TEST
+
+START_TEST (sbuxton_set_uint32_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	uint32_t uint32_val = 5;
+	errno = 0;
+	sbuxton_set_uint32("uint32key", uint32_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set uint32 failed");
+}
+END_TEST
+
+START_TEST (sbuxton_get_uint32_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	uint32_t uint32_val = 5;
+	errno = 0;
+	sbuxton_set_uint32("uint32key", uint32_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set uint32 failed");
+	errno = 0;
+	uint32_t ret = sbuxton_get_uint32("uint32key");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Get uint32 failed");
+	fail_if(ret != uint32_val, "Get uint32 returned wrong value");
+}
+END_TEST
+
+START_TEST (sbuxton_set_int64_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	int64_t int64_val = 5;
+	errno = 0;
+	sbuxton_set_int64("int64key", int64_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set int64 failed");
+}
+END_TEST
+
+START_TEST (sbuxton_get_int64_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	int64_t int64_val = 5;
+	errno = 0;
+	sbuxton_set_int64("int64key", int64_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set int64 failed");
+	errno = 0;
+	int64_t ret = sbuxton_get_int64("int64key");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Get int64 failed");
+	fail_if(ret != int64_val, "Get int64 returned wrong value");
+}
+END_TEST
+
+START_TEST (sbuxton_set_uint64_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	uint64_t uint64_val = 5;
+	errno = 0;
+	sbuxton_set_uint64("uint64key", uint64_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set uint64 failed");
+}
+END_TEST
+
+START_TEST (sbuxton_get_uint64_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	uint64_t uint64_val = 5;
+	errno = 0;
+	sbuxton_set_uint64("uint64key", uint64_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set uint64 failed");
+	errno = 0;
+	uint64_t ret = sbuxton_get_uint64("uint64key");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Get uint64 failed");
+	fail_if(ret != uint64_val, "Get uint64 returned wrong value");
+}
+END_TEST
+
+START_TEST (sbuxton_set_float_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	float float_val = 5.5;
+	errno = 0;
+	sbuxton_set_float("floatkey", float_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set float failed");
+}
+END_TEST
+
+START_TEST (sbuxton_get_float_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	float float_val = 5.5;
+	errno = 0;
+	sbuxton_set_float("floatkey", float_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set float failed");
+	errno = 0;
+	float ret = sbuxton_get_float("floatkey");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Get float failed");
+	fail_if(ret != float_val, "Get float returned wrong value");
+}
+END_TEST
+
+START_TEST (sbuxton_set_double_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	double double_val = 5;
+	errno = 0;
+	sbuxton_set_double("double", double_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set double failed");
+}
+END_TEST
+
+START_TEST (sbuxton_get_double_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	double double_val = 5;
+	errno = 0;
+	sbuxton_set_double("doublekey", double_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set double failed");
+	errno = 0;
+	double ret = sbuxton_get_double("doublekey");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Get double failed");
+	fail_if(ret != double_val, "Get double returned wrong value");
+}
+END_TEST
+
+START_TEST (sbuxton_set_bool_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	bool bool_val = false;
+	errno = 0;
+	sbuxton_set_bool("boolkey", bool_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set bool failed");
+}
+END_TEST
+
+START_TEST (sbuxton_get_bool_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	bool bool_val = false;
+	errno = 0;
+	sbuxton_set_bool("boolkey", bool_val);
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Set bool failed");
+	errno = 0;
+	bool ret = sbuxton_get_bool("boolkey");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Get bool failed");
+	fail_if(ret != bool_val, "Get bool returned wrong value");
+}
+END_TEST
+
+START_TEST (sbuxton_remove_group_check)
+{
+	errno = 0;	
+	sbuxton_set_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	sbuxton_remove_group("tg_s0", "user");
+	fail_if(errno == ENOTCONN, "Connection failed");
+	fail_if(errno == EACCES, "Removal Failed");
+	//wait to do this test until michelle puts errno in this func
+}
+END_TEST
+
+/* Start buxtonsimple-internal tests */
+START_TEST (client_connection_check)
+{
+	int ret;
+	ret = _client_connection();
+	fail_if(!ret, "Client connection failed- returned 0");
+	fail_if(client == NULL, "could not open client connection");
+}
+END_TEST
+
+START_TEST (client_disconnect_check)
+{
+	int ret;
+	ret = _client_connection();
+	fail_if(!ret, "Client connection failed- returned 0");
+	fail_if(client == NULL, "could not open client connection");
+	_client_disconnect();
+	fail_if(client != NULL, "could not close client connection");
+}
+END_TEST
+
+START_TEST (cg_cb_check)
+{
+	_BuxtonResponse resp;
+	resp.data = NULL;
+	resp.type = BUXTON_CONTROL_CHANGED;
+	resp.key = NULL;
+
+	int data = 7;
+
+	_cg_cb(&resp, &data);
+}
+END_TEST
+
+START_TEST (bs_print_check)
+{
+	vstatus *data = malloc(sizeof(*data));
+	fail_if(!data, "Failed to allocate space for vstatus");
+	data->status = 1;
+	data->type = STRING;
+	data->val.sval = "test";
+
+	BuxtonKey key = buxton_key_create("tg_s0", "keyname", "user", STRING);
+	_BuxtonResponse resp;
+	resp.data = NULL;
+	resp.type = BUXTON_CONTROL_GET;
+	BuxtonControlMessage bcm = buxton_response_type(&resp);
+	fail_if(bcm !=BUXTON_CONTROL_GET, "Response type incorrect");
+	resp.key = key;
+
+	_bs_print(data, &resp);
+	free(data);
+}
+END_TEST
+
+START_TEST (bs_cb_check)
+{
+	vstatus data;
+	data.status = 1;
+	data.type = STRING;
+	data.val.sval = "test";
+
+	BuxtonKey key = buxton_key_create("tg_s0", "keyname", "user", STRING);
+	_BuxtonResponse resp;
+	resp.data = NULL;
+	resp.type = BUXTON_CONTROL_GET;
+	BuxtonControlMessage bcm = buxton_response_type(&resp);
+	fail_if(bcm !=BUXTON_CONTROL_GET, "Response type incorrect");
+	resp.key = key;
+
+	_bs_cb(&resp, &data);
+}
+END_TEST
+
+START_TEST (bg_cb_check)
+{
+	vstatus data;
+	data.type = STRING;
+	BuxtonKey key = buxton_key_create("tg_s0", "keyname", "user", STRING);
+	BuxtonData bd;
+	bd.type = STRING;
+	bd.store.d_string = buxton_string_pack("test");
+	BuxtonArray *a = buxton_array_new();
+	fail_if(!buxton_array_add(a, &bd), "Unable to add element to array");
+	_BuxtonResponse resp;
+	resp.data = a;
+	fail_if (!buxton_array_get(resp.data, 0), "No array in resp.data");
+	resp.type = BUXTON_CONTROL_CHANGED;
+	BuxtonControlMessage bcm = buxton_response_type(&resp);
+	fail_if(bcm !=BUXTON_CONTROL_CHANGED, "Response type incorrect");
+	resp.key = key;
+	_bg_cb(&resp, &data);
+}
+END_TEST
+
+START_TEST (buxton_group_create_check)
+{
+	BuxtonKey key = _buxton_group_create("tg_s0", "user");
+	fail_if(!key, "Failed to create group key");
+}
+END_TEST
+
+START_TEST (rg_cb_check)
+{
+	int stat = 0;
+	_BuxtonResponse resp;
+	resp.data = NULL;
+	resp.type = BUXTON_CONTROL_CHANGED;
+	resp.key = NULL;
+
+	_rg_cb(&resp, &stat);
+}
+END_TEST
+
+static Suite *
+buxtonsimp_suite(void)
+{
+	Suite *s;
+	TCase *tc;
+
+	s = suite_create("buxtonsimple");
+
+	/* run in this order so group is set up for all sets and gets */
+	tc = tcase_create("buxtonsimple_public");
+	tcase_add_unchecked_fixture(tc, setup, teardown);
+	tcase_add_test(tc, sbuxton_set_group_check);
+	tcase_add_test(tc, sbuxton_set_int32_check);
+	tcase_add_test(tc, sbuxton_get_int32_check);
+	tcase_add_test(tc, sbuxton_set_string_check);
+	tcase_add_test(tc, sbuxton_get_string_check);
+	tcase_add_test(tc, sbuxton_set_uint32_check);
+	tcase_add_test(tc, sbuxton_get_uint32_check);
+	tcase_add_test(tc, sbuxton_set_int64_check);
+	tcase_add_test(tc, sbuxton_get_int64_check);
+	tcase_add_test(tc, sbuxton_set_uint64_check);
+	tcase_add_test(tc, sbuxton_get_uint64_check);
+	tcase_add_test(tc, sbuxton_set_float_check);
+	tcase_add_test(tc, sbuxton_get_float_check);
+	tcase_add_test(tc, sbuxton_set_double_check);
+	tcase_add_test(tc, sbuxton_get_double_check);
+	tcase_add_test(tc, sbuxton_set_bool_check);
+	tcase_add_test(tc, sbuxton_get_bool_check);
+	tcase_add_test(tc, sbuxton_remove_group_check);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("buxtonsimple_internal");
+	tcase_add_test(tc, client_connection_check);
+	tcase_add_test(tc, client_disconnect_check);
+	tcase_add_test(tc, cg_cb_check);
+	tcase_add_test(tc, bs_print_check);
+	tcase_add_test(tc, bs_cb_check);
+	tcase_add_test(tc, bg_cb_check);
+	tcase_add_test(tc, buxton_group_create_check);
+	tcase_add_test(tc, rg_cb_check);
+	suite_add_tcase(s, tc);
+
+	return s;
+}
+
+int main(void)
+{
+	int number_failed;
+	Suite *s;
+	SRunner *sr;
+
+	putenv("BUXTON_CONF_FILE=" ABS_TOP_BUILDDIR "/test/test.conf");
+	putenv("BUXTON_ROOT_CHECK=0");
+	s = buxtonsimp_suite();
+	sr = srunner_create(s);
+	srunner_run_all(sr, CK_VERBOSE);
+	number_failed = srunner_ntests_failed(sr);
+	srunner_free(sr);
+
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
BuxtonSimple is an API that allows users who are new to Buxton or
familiar with vconf to utilize Buxton. There are fewer function
arguments for each function.  This is possibile because there are
default call back functions and a global client provided in
the library. There are also newer functions similar to those found
in the vconf API (such has set_int32). The opening and closing of the
client connection is embedded into each function called so the programmer
does not have to call buxton_open() or buxton_close().

There is a library called libbuxtonsimple that can be linked to by a client
program when using BuxtonSimple (-lbuxtonsimple). This exposes only the
funcitons in the BuxtonSimple API, without the functions from the original
Buxton API.

Man pages for the BuxtonSimple API and all public functinos are included as
well as demo code.

Test units are also included in the /test directory.
