### PR TITLE
Setting the const attribute to strings of API

### DIFF
--- a/src/include/buxton.h
+++ b/src/include/buxton.h
@@ -104,7 +104,7 @@ typedef void (*BuxtonCallback)(BuxtonResponse, void *);
  * @param path Path to the buxton configuration file to use
  * @return An int with 0 indicating success or an errno value
  */
-_bx_export_ int buxton_set_conf_file(char *path);
+_bx_export_ int buxton_set_conf_file(const char *path);
 
 /**
  * Open a connection to Buxton
@@ -155,7 +155,7 @@ _bx_export_ int buxton_set_value(BuxtonClient client,
  */
 _bx_export_ int buxton_set_label(BuxtonClient client,
 				 BuxtonKey key,
-				 char *value,
+				 const char *value,
 				 BuxtonCallback callback,
 				 void *data,
 				 bool sync)
@@ -221,7 +221,7 @@ _bx_export_ int buxton_get_value(BuxtonClient client,
  * @return An boolean value, indicating success of the operation
  */
 _bx_export_ int buxton_client_list_keys(BuxtonClient client,
-					char *layer_name,
+					const char *layer_name,
 					BuxtonCallback callback,
 					void *data,
 					bool sync)
@@ -292,8 +292,8 @@ _bx_export_ ssize_t buxton_client_handle_response(BuxtonClient client)
  * @param layer Pointer to a character string representing a layer (optional)
  * @return A pointer to a BuxtonString containing the key
  */
-_bx_export_ BuxtonKey buxton_key_create(char *group, char *name, char *layer,
-				      BuxtonDataType type)
+_bx_export_ BuxtonKey buxton_key_create(const char *group, const char *name,
+					const char *layer, BuxtonDataType type)
 	__attribute__((warn_unused_result));
 
 /**

--- a/src/libbuxton/lbuxton.c
+++ b/src/libbuxton/lbuxton.c
@@ -43,7 +43,7 @@
 
 static Hashmap *key_hash = NULL;
 
-int buxton_set_conf_file(char *path)
+int buxton_set_conf_file(const char *path)
 {
 	int r;
 	struct stat st;
@@ -274,7 +274,7 @@ int buxton_set_value(BuxtonClient client,
 
 int buxton_set_label(BuxtonClient client,
 		     BuxtonKey key,
-		     char *value,
+		     const char *value,
 		     BuxtonCallback callback,
 		     void *data,
 		     bool sync)
@@ -289,7 +289,7 @@ int buxton_set_label(BuxtonClient client,
 	}
 
 	k->type = STRING;
-	v = buxton_string_pack(value);
+	v = buxton_string_pack((char*)value); /* discarding const is okay */
 
 	r = buxton_wire_set_label((_BuxtonClient *)client, k, &v, callback,
 				  data);
@@ -376,7 +376,7 @@ int buxton_remove_group(BuxtonClient client,
 }
 
 int buxton_client_list_keys(BuxtonClient client,
-			    char *layer_name,
+			    const char *layer_name,
 			    BuxtonCallback callback,
 			    void *data,
 			    bool sync)
@@ -389,7 +389,7 @@ int buxton_client_list_keys(BuxtonClient client,
 		return EINVAL;
 	}
 
-	l = buxton_string_pack(layer_name);
+	l = buxton_string_pack((char*)layer_name); /* discarding const is okay */
 
 	r = buxton_wire_list_keys((_BuxtonClient *)client, &l, callback, data);
 	if (!r) {
@@ -440,8 +440,8 @@ int buxton_unset_value(BuxtonClient client,
 	return ret;
 }
 
-BuxtonKey buxton_key_create(char *group, char *name, char *layer,
-			  BuxtonDataType type)
+BuxtonKey buxton_key_create(const char *group, const char *name, 
+			  const char *layer, BuxtonDataType type)
 {
 	_BuxtonKey *key = NULL;
 	char *g = NULL;

--- a/src/shared/configurator.c
+++ b/src/shared/configurator.c
@@ -238,7 +238,7 @@ __attribute__ ((destructor)) static void free_conf(void)
 	iniparser_freedict(conf.ini);
 }
 
-void buxton_add_cmd_line(ConfigKey confkey, char* data)
+void buxton_add_cmd_line(ConfigKey confkey, const char* data)
 {
 	if (confkey >= CONFIG_MAX || confkey <= CONFIG_MIN) {
 		buxton_log("invalid confkey");

--- a/src/shared/configurator.h
+++ b/src/shared/configurator.h
@@ -50,7 +50,7 @@ typedef struct ConfigLayer {
  *
  * @note This API is draft
  */
-void buxton_add_cmd_line(ConfigKey confkey, char* data);
+void buxton_add_cmd_line(ConfigKey confkey, const char* data);
 
 /**
  * @internal


### PR DESCRIPTION
Because clients are often using "const char *" instead
of just "char *" in their internal API, it make sense
to offer this new API. Their are two main reasons:
- passing a "char_" for a "const char_" is okay and
  doesn't produce warning.
- the developper doesn't have to ask himself if removing
  the const with a cast is okay or not.

Change-Id: I4640def0d512bad63049b42a0cf449ff6c9f7b08
