### PR TITLE
Implemented get_key_type feature in libbuxton, daemon, and buxtonctl

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,7 @@ dist_man_MANS = \
 	docs/buxton_client_handle_response.3 \
 	docs/buxton_close.3 \
 	docs/buxton_create_group.3 \
+	docs/buxton_get_key_type.3 \
 	docs/buxton_get_value.3 \
 	docs/buxton_key_create.3 \
 	docs/buxton_key_free.3 \
@@ -448,6 +449,7 @@ check_DATA = \
 if BUILD_DEMOS
 bin_PROGRAMS += \
 	bxt_timing \
+	bxt_hello_get_key_type \
 	bxt_hello_get \
 	bxt_hello_set \
 	bxt_hello_set_label \
@@ -465,6 +467,13 @@ bxt_timing_LDADD = \
 	libbuxton.la \
 	libbuxton-shared.la \
 	-lrt -lm
+
+bxt_hello_get_key_type_SOURCES = \
+	demo/hellogetkeytype.c
+bxt_hello_get_key_type_CFLAGS = \
+	$(AM_CFLAGS)
+bxt_hello_get_key_type_LDADD =\
+	libbuxton.la
 
 bxt_hello_get_SOURCES = \
 	demo/helloget.c

--- a/demo/hellogetkeytype.c
+++ b/demo/hellogetkeytype.c
@@ -1,0 +1,171 @@
+/*
+ * This file is part of buxton.
+ *
+ * Copyright (C) 2013 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/*
+ * Run this demo after creating the group with bxt_hello_create_group
+ * and after setting the key with bxt_hello_set
+ */
+
+#define _GNU_SOURCE
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "buxton.h"
+
+void get_cb(BuxtonResponse response, void *data)
+{
+	BuxtonDataType *ret = (BuxtonDataType*) data;
+
+	if (buxton_response_status(response) != 0) {
+		
+		printf("Failed to get value\n");
+		return;
+	} else {
+		printf("Get successful, got type\n");
+		void *p = buxton_response_value(response);
+		*ret = *(BuxtonDataType*)p;
+		return;
+	}
+}
+
+int main(void)
+{
+	BuxtonClient client;
+	BuxtonKey key;
+	struct pollfd pfd[1];
+	int r;
+	BuxtonDataType d_type = BUXTON_TYPE_MIN;
+	int fd;
+	char *type;
+
+	if ((fd = buxton_open(&client)) < 0) {
+		printf("couldn't connect\n");
+		return -1;
+	}
+
+/*
+ * A fully qualified key-name is being created since both group and key-name are not null.
+ * Group: "hello", Key-name: "test", Layer: "user", DataType: UNKNOWN
+ */
+	key = buxton_key_create("hello", "test", "user", UNKNOWN);
+	if (!key) {
+		return -1;
+	}
+
+	if (buxton_get_key_type(client, key, get_cb,
+			     &d_type, false)) {
+		printf("get call failed to run\n");
+		return -1;
+	}
+
+	pfd[0].fd = fd;
+	pfd[0].events = POLLIN;
+	pfd[0].revents = 0;
+	r = poll(pfd, 1, 5000);
+
+	if (r <= 0) {
+		printf("poll error\n");
+		return -1;
+	}
+
+	if (!buxton_client_handle_response(client)) {
+		printf("bad response from daemon\n");
+		return -1;
+	}
+
+	switch (d_type) {
+		case BUXTON_TYPE_MIN:
+		{
+			type = "invalid- still min";
+		}
+		case STRING:
+		{
+			type = "string";
+			break;
+		}
+		case INT32:
+		{
+			type = "int32_t";
+			break;
+		}
+		case UINT32:
+		{
+			type = "uint32_t";
+			break;
+		}
+		case INT64:
+		{
+			type = "int64_t";
+			break;
+		}
+		case UINT64:
+		{
+			type = "uint64_t";
+			break;
+		}
+		case FLOAT:
+		{
+			type = "float";
+			break;
+		}
+		case DOUBLE:
+		{
+			type = "double";
+			break;
+		}
+		case BOOLEAN:
+		{
+			type = "bool";
+			break;
+		}
+		default:
+		{
+			type = "unknown";
+			break;
+		}
+	}
+
+	printf("type of key is: %d = %s\n", d_type, type);
+	
+	buxton_key_free(key);
+	buxton_close(client);
+	return 0;
+}
+
+/*
+ * Editor modelines  -	http://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: t
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 noexpandtab:
+ * :indentSize=8:tabSize=8:noTabs=false:
+ */

--- a/docs/buxton-api.7
+++ b/docs/buxton-api.7
@@ -82,6 +82,9 @@ use these API functions\&.
 \fBbuxton_get_value\fR(3)
 \(em Get the value of a key
 .br
+\fBbuxton_get_key_type\fR(3)
+\(em Get the type of a key
+.br
 \fBbuxton_unset_value\fR(3)
 \(em Unset the value for a key
 .br

--- a/docs/buxton_get_key_type.3
+++ b/docs/buxton_get_key_type.3
@@ -1,0 +1,218 @@
+'\" t
+.TH "BUXTON_GET_KEY_TYPE" "3" "buxton 1" "buxton_get_key_type"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+buxton_get_key_type \- Get the type of value for a key\-name
+
+.SH "SYNOPSIS"
+.nf
+\fB
+#include <buxton.h>
+\fR
+.sp
+\fB
+int buxton_get_key_type(BuxtonClient \fIclient\fB,
+.br
+                     BuxtonKey \fIkey\fB,
+.br
+                     BuxtonCallback \fIcallback\fB,
+.br
+                     void *\fIdata\fB,
+.br
+                     bool \fIsync\fB)
+\fR
+.fi
+
+.SH "DESCRIPTION"
+.PP
+This function is used to get the type of value for a key\-name for
+\fIclient\fR. The key\-name is referenced by \fIkey\fR. The key\-type
+must be set to UNKNOWN. If the layer
+for \fIkey\fR is NULL, buxton will traverse layers in priority order
+searching for the key-name value, selecting the value for the first
+key\-name found\&. If the argument is non-NULL, the operation will
+target only that layer\&. For more information on creating a
+BuxtonKey to pass for \fIkey\fR, see \fBbuxton_key_create\fR(3)\&.
+
+To retrieve the result of the operation, clients should define a
+callback function, referenced by the \fIcallback\fR argument; the
+callback function is called upon completion of the operation\&. The
+\fIdata\fR argument is a pointer to arbitrary userdata that is passed
+along to the callback function\&. Additonally, the \fIsync\fR
+argument controls whether the operation should be synchronous or not;
+if \fIsync\fR is false, the operation is asynchronous\&.
+
+.SH "CODE EXAMPLE"
+.nf
+.sp
+#define _GNU_SOURCE
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "buxton.h"
+
+void get_cb(BuxtonResponse response, void *data)
+{
+	BuxtonDataType *ret = (BuxtonDataType*) data;
+
+	if (buxton_response_status(response) != 0) {
+		
+		printf("Failed to get value\\n");
+		return;
+	} else {
+		printf("Get successful, got type\\n");
+		void *p = buxton_response_value(response);
+		*ret = *(BuxtonDataType*)p;
+		return;
+	}
+}
+
+int main(void)
+{
+	BuxtonClient client;
+	BuxtonKey key;
+	struct pollfd pfd[1];
+	int r;
+	BuxtonDataType d_type = BUXTON_TYPE_MIN;
+	int fd;
+	char *type;
+
+	if ((fd = buxton_open(&client)) < 0) {
+		printf("couldn't connect\\n");
+		return -1;
+	}
+
+/*
+ * A fully qualified key-name is being created since both group and key-name are not null.
+ * Group: "hello", Key-name: "test", Layer: "user", DataType: UNKNOWN
+ */
+	key = buxton_key_create("hello", "test", "user", UNKNOWN);
+	if (!key) {
+		return -1;
+	}
+
+	if (buxton_get_key_type(client, key, get_cb,
+			     &d_type, false)) {
+		printf("get call failed to run\\n");
+		return -1;
+	}
+
+	pfd[0].fd = fd;
+	pfd[0].events = POLLIN;
+	pfd[0].revents = 0;
+	r = poll(pfd, 1, 5000);
+
+	if (r <= 0) {
+		printf("poll error\n");
+		return -1;
+	}
+
+	if (!buxton_client_handle_response(client)) {
+		printf("bad response from daemon\\n");
+		return -1;
+	}
+
+	switch (d_type) {
+		case BUXTON_TYPE_MIN:
+		{
+			type = "invalid- still min";
+		}
+		case STRING:
+		{
+			type = "string";
+			break;
+		}
+		case INT32:
+		{
+			type = "int32_t";
+			break;
+		}
+		case UINT32:
+		{
+			type = "uint32_t";
+			break;
+		}
+		case INT64:
+		{
+			type = "int64_t";
+			break;
+		}
+		case UINT64:
+		{
+			type = "uint64_t";
+			break;
+		}
+		case FLOAT:
+		{
+			type = "float";
+			break;
+		}
+		case DOUBLE:
+		{
+			type = "double";
+			break;
+		}
+		case BOOLEAN:
+		{
+			type = "bool";
+			break;
+		}
+		default:
+		{
+			type = "unknown";
+			break;
+		}
+	}
+
+	printf("type of key is: %d = %s\\n", d_type, type);
+	
+	buxton_key_free(key);
+	buxton_close(client);
+	return 0;
+}
+.fi
+
+.SH "RETURN VALUE"
+.PP
+Returns 0 on success, and a non\-zero value on failure\&.
+
+.SH "COPYRIGHT"
+.PP
+Copyright 2014 Intel Corporation\&. License: Creative Commons
+Attribution\-ShareAlike 3.0 Unported\s-2\u[1]\d\s+2, with exception
+for code examples found in the \fBCODE EXAMPLE\fR section, which are
+licensed under the MIT license provided in the \fIdocs/LICENSE.MIT\fR
+file from this buxton distribution\&.
+
+.SH "SEE ALSO"
+.PP
+\fBbuxton\fR(7),
+\fBbuxtond\fR(8),
+\fBbuxton\-api\fR(7)
+
+.SH "NOTES"
+.IP " 1." 4
+Creative Commons Attribution\-ShareAlike 3.0 Unported
+.RS 4
+\%http://creativecommons.org/licenses/by-sa/3.0/
+.RE

--- a/docs/buxtonctl.1
+++ b/docs/buxtonctl.1
@@ -162,6 +162,11 @@ Gets a key value with boolean type\&.
 Sets a key value with boolean type\&.
 .RE
 .PP
+\fBget\-key\-type\fR [LAYER] GROUP KEY
+.RS 4
+Gets the type of value for a key
+.RE
+.PP
 \fBset\-label\fR LAYER GROUP KEY LABEL
 .RS 4
 Sets the Smack label on a key\&. Note that this is a privileged

--- a/src/cli/client.c
+++ b/src/cli/client.c
@@ -335,6 +335,137 @@ bool cli_set_value(BuxtonControl *control, BuxtonDataType type,
 	return ret;
 }
 
+void get_key_type_callback(BuxtonResponse response, void *data)
+{
+	BuxtonData *r = (BuxtonData *)data;
+	void *p;
+
+	if (buxton_response_status(response) != 0) {
+		return;
+	}
+
+	p = buxton_response_value(response);
+	if (!p) {
+		return;
+	}
+	
+	r->type = UINT32;
+	r->store.d_uint32 = *(uint32_t *)p;
+}
+
+bool cli_get_key_type(BuxtonControl *control, BuxtonDataType type,
+		   char *one, char *two, char *three, __attribute__((unused)) char * four)
+{
+	BuxtonKey key;
+	BuxtonData get;
+	_cleanup_free_ char *prefix = NULL;
+	_cleanup_free_ char *group = NULL;
+	_cleanup_free_ char *name = NULL;
+	BuxtonString dlabel;
+	bool ret = false;
+	int32_t ret_val;
+	int r;
+
+	memzero((void *)&get, sizeof(BuxtonData));
+	if (three != NULL) {
+		key = buxton_key_create(two, three, one, type);
+		r = asprintf(&prefix, "[%s]", one);
+		if (!r) {
+			abort();
+		}
+	} else {
+		key = buxton_key_create(one, two, NULL, type);
+		r = asprintf(&prefix, " ");
+		if (!r) { 
+			abort();
+		}
+	}
+
+	if (!key) {
+		return false;
+	}
+
+	if (three != NULL) {
+		if (control->client.direct) {
+			ret = buxton_direct_get_value_for_layer(control, key,
+								&get, &dlabel,
+								NULL);
+		} else {
+			ret = buxton_get_key_type(&control->client, key,
+							get_key_type_callback,
+							&get, true);
+		}
+		if (ret) {
+			group = get_group(key);
+			name = get_name(key);
+			printf("Requested key was not found in layer \'%s\': %s:%s\n",
+				one, nv(group), nv(name));
+			return false;
+		}
+	} else {
+		if (control->client.direct) {
+			ret_val = buxton_direct_get_value(control, key, &get,
+							&dlabel, NULL);
+			if (ret_val == 0) {
+				ret = true;     
+			}
+		} else {
+			ret = buxton_get_key_type(&control->client, key,
+							get_key_type_callback,
+							&get, true);
+		}
+		if (ret) {
+			group = get_group(key);
+			name = get_name(key);
+			printf("Requested key was not found: %s:%s\n", nv(group),
+				nv(name));
+			return false;
+		}
+	}
+
+	group = get_group(key);
+	name = get_name(key);
+	if (get.type != UINT32) {
+		printf("Get Key Type did not return a BuxtonDataType.\n");
+		return false;
+	}
+
+	switch ((BuxtonDataType)get.store.d_uint32) {
+	case STRING:
+		printf("%s%s:%s = STRING \n", prefix, nv(group), nv(name));
+		break;
+	case INT32:
+		printf("%s%s:%s = INT32 \n", prefix, nv(group), nv(name));
+		break;
+	case UINT32:
+		printf("%s%s:%s = UINT32 \n", prefix, nv(group), nv(name));
+		break;
+	case INT64:
+		printf("%s%s:%s = INT64 \n", prefix, nv(group), nv(name));
+		break;
+	case UINT64:
+		printf("%s%s:%s = UINT64 \n", prefix, nv(group), nv(name));
+		break;
+	case FLOAT:
+		printf("%s%s:%s = FLOAT \n", prefix, nv(group), nv(name));
+		break;
+	case DOUBLE:
+		printf("%s%s:%s = DOUBLE \n", prefix, nv(group), nv(name));
+		break;
+	case BOOLEAN:
+		printf("%s%s:%s = BOOLEAN \n", prefix, nv(group), nv(name));
+		break;
+	case BUXTON_TYPE_MIN:
+		printf("Requested key was not found: %s:%s\n", nv(group), nv(name));
+		return false;
+	default:
+		printf("unknown type\n");
+		return false;
+	}
+
+	return true; 
+}
+
 void get_value_callback(BuxtonResponse response, void *data)
 {
 	BuxtonKey key;

--- a/src/cli/client.h
+++ b/src/cli/client.h
@@ -143,6 +143,21 @@ bool cli_set_value(BuxtonControl *control, BuxtonDataType type, char *one,
 	__attribute__((warn_unused_result));
 
 /**
+ * Get a key type from Buxton
+ * @param control An initialized control structure
+ * @param type Type of key used to request type
+ * @param one Layer or Group of data being set
+ * @param two  or key of data being set
+ * @param two Key if one is Layer
+ * @param three NULL (unused)
+ * @returns bool indicating success or failure
+ */
+bool cli_get_key_type(BuxtonControl *control, BuxtonDataType type, char *one,
+		   char *two, char *three,
+		   __attribute__((unused)) char *four)
+	__attribute__((warn_unused_result));
+
+/**
  * Get a value from Buxton
  * @param control An initialized control structure
  * @param type Type of data being sought

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -90,6 +90,7 @@ int main(int argc, char **argv)
 	Command c_get_float, c_set_float;
 	Command c_get_double, c_set_double;
 	Command c_get_bool, c_set_bool;
+	Command c_get_key_type;
 	Command c_set_label;
 	Command c_create_group, c_remove_group;
 	Command c_unset_value;
@@ -185,6 +186,11 @@ int main(int argc, char **argv)
 	c_set_bool = (Command) { "set-bool", "Set a key with a boolean value",
 				 4, 4, "layer group name value", &cli_set_value, BOOLEAN };
 	hashmap_put(commands, c_set_bool.name, &c_set_bool);
+
+	/* Get key type */
+	c_get_key_type = (Command) { "get-key-type", "Get the data type of a key",
+				2, 3, "[layer] group name", &cli_get_key_type, UNKNOWN };
+	hashmap_put(commands, c_get_key_type.name, &c_get_key_type);
 
 	/* SMACK labels */
 	c_set_label = (Command) { "set-label", "Set a value's label",

--- a/src/core/daemon.h
+++ b/src/core/daemon.h
@@ -146,6 +146,18 @@ void remove_group(BuxtonDaemon *self, client_list_item *client,
 		  _BuxtonKey *key, int32_t *status);
 
 /**
+ * Buxton daemon function for getting the type of a key
+ * @param self buxtond instance being run
+ * @param client Used to validate smack access
+ * @param key Key for the value being sought
+ * @param status Will be set with the int32_t result of the operation
+ * @returns BuxtonData Value stored for key if successful otherwise NULL
+ */
+BuxtonData *get_key_type(BuxtonDaemon *self, client_list_item *client,
+			_BuxtonKey *key, int32_t *status)
+	__attribute__((warn_unused_result));
+
+/**
  * Buxton daemon function for getting a value
  * @param self buxtond instance being run
  * @param client Used to validate smack access

--- a/src/db/gdbm.c
+++ b/src/db/gdbm.c
@@ -197,6 +197,81 @@ end:
 	return ret;
 }
 
+static int get_key_type(BuxtonLayer *layer, _BuxtonKey *key, BuxtonData *data,
+			BuxtonString *label)
+{
+	GDBM_FILE db;
+	datum key_data;
+	datum value;
+	uint8_t *data_store = NULL;
+	int ret;
+	uint32_t sz;
+	BuxtonData *temp_data;
+
+	assert(layer);
+
+	temp_data = malloc0(sizeof(BuxtonData));
+	if (!temp_data) {
+		abort();
+	}
+
+	if (key->name.value) {
+		sz = key->group.length + key->name.length;
+		key_data.dptr = malloc(sz);
+		if (!key_data.dptr) {
+			abort();
+		}
+
+		/* size is string\0string\0 so just write, bonus for
+		   nil seperator being added without extra work */
+		key_data.dsize = (int)sz;
+		memcpy(key_data.dptr, key->group.value, key->group.length);
+		memcpy(key_data.dptr + key->group.length, key->name.value,
+			key->name.length);
+	} else {
+		key_data.dptr = malloc(key->group.length);
+		if (!key_data.dptr) {
+			abort();
+		}
+
+		memcpy(key_data.dptr, key->group.value, key->group.length);
+		key_data.dsize = (int)key->group.length;
+	}
+
+	memzero(&value, sizeof(datum));
+	db = db_for_resource(layer);
+	if (!db) {
+		/*
+		 * Set negative here to indicate layer not found
+		 * rather than key not found, optimization for
+		 * set value
+		 */
+		ret = -ENOENT;
+		goto end;
+	}
+
+	value = gdbm_fetch(db, key_data);
+	if (value.dsize <0 || value.dptr == NULL) {
+		ret = ENOENT;
+		goto end;
+	}
+
+	data_store = (uint8_t*)value.dptr;
+	buxton_deserialize(data_store, temp_data, label);
+
+	data->type = UINT32;
+	data->store.d_uint32 = temp_data->type;
+	ret = 0;
+
+end:
+	free(key_data.dptr);
+	free(value.dptr);
+	free(temp_data);
+	data_store = NULL;
+
+	return ret;
+}
+
 static int get_value(BuxtonLayer *layer, _BuxtonKey *key, BuxtonData *data,
 		      BuxtonString *label)
 {
@@ -425,6 +500,7 @@ _bx_export_ bool buxton_module_init(BuxtonBackend *backend)
 
 	/* Point the struct methods back to our own */
 	backend->set_value = &set_value;
+	backend->get_key_type = &get_key_type;
 	backend->get_value = &get_value;
 	backend->list_keys = &list_keys;
 	backend->unset_value = &unset_value;

--- a/src/include/buxton.h
+++ b/src/include/buxton.h
@@ -53,6 +53,7 @@ typedef enum BuxtonDataType {
 	FLOAT, /**<Represents type of a float value */
 	DOUBLE, /**<Represents type of a double value */
 	BOOLEAN, /**<Represents type of a boolean value */
+	UNKNOWN, /**<Represents an unknown type of value */
 	BUXTON_TYPE_MAX
 } BuxtonDataType;
 
@@ -65,6 +66,7 @@ typedef enum BuxtonControlMessage {
 	BUXTON_CONTROL_SET_LABEL, /**<Set a label within Buxton */
 	BUXTON_CONTROL_CREATE_GROUP, /**<Create a group within Buxton */
 	BUXTON_CONTROL_REMOVE_GROUP, /**<Remove a group within Buxton */
+	BUXTON_CONTROL_GET_KEY_TYPE, /**<Retrieve the type of a key */
 	BUXTON_CONTROL_GET, /**<Retrieve a value from Buxton */
 	BUXTON_CONTROL_UNSET, /**<Unset a value within Buxton */
 	BUXTON_CONTROL_LIST, /**<List keys within a Buxton layer */
@@ -193,6 +195,22 @@ _bx_export_ int buxton_remove_group(BuxtonClient client,
 				    BuxtonCallback callback,
 				    void *data,
 				    bool sync)
+	__attribute__((warn_unused_result));
+
+/**
+ * Retrieve a key's type from Buxton
+ * @param client An open client connection
+ * @param key The key to retrieve
+ * @param callback A callback function to handle daemon reply
+ * @param data User data to be used with callback function
+ * @param sync Indicator for running a synchronous request
+ * @return An int value, indicating success of the operation
+ */
+_bx_export_ int buxton_get_key_type(BuxtonClient client,
+				BuxtonKey key,
+				BuxtonCallback callback,
+				void *data,
+				bool sync)
 	__attribute__((warn_unused_result));
 
 /**

--- a/src/libbuxton/lbuxton.sym
+++ b/src/libbuxton/lbuxton.sym
@@ -7,6 +7,7 @@ BUXTON_1 {
 		buxton_set_label;
 		buxton_create_group;
 		buxton_remove_group;
+		buxton_get_key_type;
 		buxton_get_value;
 		buxton_unset_value;
 		buxton_register_notification;

--- a/src/shared/backend.c
+++ b/src/shared/backend.c
@@ -249,6 +249,7 @@ void destroy_backend(BuxtonBackend *backend)
 	assert(backend);
 
 	backend->set_value = NULL;
+	backend->get_key_type = NULL;
 	backend->get_value = NULL;
 	backend->list_keys = NULL;
 	backend->unset_value = NULL;

--- a/src/shared/backend.h
+++ b/src/shared/backend.h
@@ -104,6 +104,7 @@ typedef struct BuxtonBackend {
 	void *module; /**<Private handle to the module */
 	module_destroy_func destroy; /**<Destroy method */
 	module_value_func set_value; /**<Set value function */
+	module_value_func get_key_type; /**<Get key type function */
 	module_value_func get_value; /**<Get value function */
 	module_list_func list_keys; /**<List keys function */
 	module_value_func unset_value; /**<Unset value function */

--- a/src/shared/direct.c
+++ b/src/shared/direct.c
@@ -172,7 +172,12 @@ int buxton_direct_get_value_for_layer(BuxtonControl *control,
 		}
 	}
 
-	ret = backend->get_value(layer, key, data, data_label);
+	if (key->type == UNKNOWN) {
+		ret = backend->get_key_type(layer, key, data, data_label);
+	} else {
+		ret = backend->get_value(layer, key, data, data_label);
+	}
+
 	if (!ret) {
 		/* Access checks are not needed for direct clients, where client_label is NULL */
 		if (data_label->value && client_label && client_label->value &&

--- a/src/shared/direct.h
+++ b/src/shared/direct.h
@@ -100,6 +100,38 @@ bool buxton_direct_set_value(BuxtonControl *control,
 	__attribute__((warn_unused_result));
 
 /**
+ * Retrieve a key type from Buxton
+ * @param control An initialized control structure
+ * @param key The key to retrieve
+ * @param data An empty BuxtonData, where data is stored
+ * @param data_label The Smack label of the data
+ * @param client_label The Smack label of the client
+ * @return A int32_t value, indicating success of the operation
+ */
+int32_t buxton_direct_get_key_type(BuxtonControl *control,
+				_BuxtonKey *key,
+				BuxtonData *data,
+				BuxtonString *data_label,
+				BuxtonString *client_label)
+	__attribute__((warn_unused_result));
+
+/**
+ * Retrieve a key type from Buxton by layer
+ * @param control An initialized control structure
+ * @param key The key to retrieve
+ * @param data An empty BuxtonData, where type is stored
+ * @param data_label The Smack label of the data
+ * @param client_label The Smack label of the client
+ * @return An int value, indicating success of the operation
+ */
+int buxton_direct_get_key_type_for_layer(BuxtonControl *control,
+				       _BuxtonKey *key,
+				       BuxtonData *data,
+				       BuxtonString *data_label,
+				       BuxtonString *client_label)
+	__attribute__((warn_unused_result));
+
+/**
  * Retrieve a value from Buxton
  * @param control An initialized control structure
  * @param key The key to retrieve

--- a/src/shared/protocol.c
+++ b/src/shared/protocol.c
@@ -664,6 +664,64 @@ end:
 	return ret;
 }
 
+bool buxton_wire_get_key_type(_BuxtonClient *client, _BuxtonKey *key,
+			BuxtonCallback callback, void *data)
+{
+	bool ret = false;
+	size_t send_len = 0;
+	_cleanup_free_ uint8_t *send = NULL;
+	BuxtonArray *list = NULL;
+	BuxtonData d_layer;
+	BuxtonData d_group;
+	BuxtonData d_name;
+	BuxtonData d_type; //do i need this?
+	uint32_t msgid = get_msgid();
+
+	buxton_string_to_data(&key->group, &d_group);
+	buxton_string_to_data(&key->name, &d_name);
+	d_type.type = UINT32; // do i need this?
+	d_type.store.d_int32 = key->type; // do i need this?
+
+	list = buxton_array_new();
+	if (key->layer.value) {
+		buxton_string_to_data(&key->layer, &d_layer);
+		if (!buxton_array_add(list, &d_layer)) {
+			buxton_log("Unable to prepare get_key_type message\n");
+			goto end;
+		}
+	}
+	if (!buxton_array_add(list, &d_group)) {
+		buxton_log("Failed to add group to get_key_type array\n");
+		goto end;
+	}
+	if (!buxton_array_add(list, &d_name)) {
+		buxton_log("Failed to add name to get_key_type array\n");
+		goto end;
+	}
+	if (!buxton_array_add(list, &d_type)) {
+		buxton_log("Failed to add type to get_key_type_array\n");
+		goto end;
+	}
+
+	send_len = buxton_serialize_message(&send, BUXTON_CONTROL_GET_KEY_TYPE,
+					msgid, list);
+
+	if (send_len == 0) {
+		goto end;
+	}
+
+	if (!send_message(client, send, send_len, callback, data, msgid,
+			BUXTON_CONTROL_GET_KEY_TYPE, key)) {
+		goto end;
+	}
+
+	ret = true;
+
+end:
+	buxton_array_free(&list, NULL);
+	return ret;
+}
+
 bool buxton_wire_get_value(_BuxtonClient *client, _BuxtonKey *key,
 			   BuxtonCallback callback, void *data)
 {

--- a/src/shared/protocol.h
+++ b/src/shared/protocol.h
@@ -161,6 +161,18 @@ bool buxton_wire_remove_group(_BuxtonClient *client, _BuxtonKey *key,
 	__attribute__((warn_unused_result));
 
 /**
+ * Send a GET_KEY_TYPE message over the wire protocol, return the type of the key
+ * @param client Client connection
+ * @param key _BuxtonKey pointer
+ * @param callback A callback function to handle daemon reply
+ * @param data User data to be used with callback functionb
+ * @return a boolean value, indicating success of the operation
+ */
+bool buxton_wire_get_key_type(_BuxtonClient *client, _BuxtonKey *key,
+				BuxtonCallback callback, void *data)
+	__attribute__((warn_unused_result));
+
+/**
  * Send a GET message over the wire protocol, return the data
  * @param client Client connection
  * @param key _BuxtonKey pointer

--- a/test/check_buxton.c
+++ b/test/check_buxton.c
@@ -142,6 +142,32 @@ START_TEST(buxton_direct_set_value_check)
 }
 END_TEST
 
+START_TEST(buxton_direct_get_key_type_for_layer_check)
+{
+	BuxtonControl c;
+	BuxtonData result;
+	BuxtonString dlabel;
+	_BuxtonKey key;
+
+	key.layer = buxton_string_pack("test-gdbm");
+	key.group = buxton_string_pack("bxt_test_group");
+	key.name = buxton_string_pack("bxt_test_key");
+	key.type = UNKNOWN;
+
+	c.client.uid = getuid();
+	fail_if(buxton_direct_open(&c) == false,
+		"Direct open failed without daemon.");
+	fail_if(buxton_direct_get_value_for_layer(&c, &key, &result, &dlabel, NULL),
+		"Retrieving key type from buxton gdbm backend failed.");
+	fail_if(result.type != UINT32,
+		"Buxton gdbm backend returned incorrect result type.");
+	//FIXME: get label test figured out
+	fail_if(result.store.d_uint32 != (uint32_t)STRING,
+		"Buxton gdbm returned a different key type to that set.");
+	buxton_direct_close(&c);
+}
+END_TEST
+
 START_TEST(buxton_direct_get_value_for_layer_check)
 {
 	BuxtonControl c;
@@ -166,6 +192,40 @@ START_TEST(buxton_direct_get_value_for_layer_check)
 		"Buxton gdbm returned a different value to that set.");
 	if (result.store.d_string.value)
 		free(result.store.d_string.value);
+	buxton_direct_close(&c);
+}
+END_TEST
+
+START_TEST(buxton_direct_get_key_type_check)
+{
+	BuxtonControl c;
+	BuxtonData data, result;
+	BuxtonString dlabel;
+	_BuxtonKey key;
+	key.layer = buxton_string_pack("test-gdbm");
+	key.group = buxton_string_pack("bxt_test_group");
+	key.name = buxton_string_pack("bxt_test_key");
+	key.type = STRING;
+
+	fail_if(buxton_direct_open(&c) == false,
+		"Direct open failed without daemon.");
+
+	c.client.uid = getuid();
+	data.type = STRING;
+	data.store.d_string = buxton_string_pack("bxt_test_value2");
+	fail_if(data.store.d_string.value == NULL,
+		"Failed to allocate test string.");
+	fail_if(buxton_direct_set_value(&c, &key, &data, NULL) == false,
+		"Failed to set second value.");
+
+	key.type = UNKNOWN;
+	fail_if(buxton_direct_get_value(&c, &key, &result, &dlabel, NULL) == -1,
+		"Retrieving key type from buxton gdbm backend failed.");
+	fail_if(result.type != UINT32,
+		"Buxton gdbm backend returned incorrect result type.");
+	//FIXME: figure out label check
+	fail_if(result.store.d_uint32 != (uint32_t)data.type,
+		"Buxton gdbm returned a different key type to that set.");
 	buxton_direct_close(&c);
 }
 END_TEST
@@ -918,6 +978,90 @@ START_TEST(buxton_wire_set_label_check)
 }
 END_TEST
 
+START_TEST(buxton_wire_get_key_type_check)
+{
+	_BuxtonClient client;
+	int server;
+	ssize_t size;
+	BuxtonData *list = NULL;
+	uint8_t buf[4096];
+	ssize_t r;
+	_BuxtonKey key;
+	BuxtonControlMessage msg;
+	uint32_t msgid;
+
+	setup_socket_pair(&(client.fd), &server);
+	fail_if(fcntl(client.fd, F_SETFL, O_NONBLOCK),
+		"Failed to set socket to non blocking");
+	fail_if(fcntl(server, F_SETFL, O_NONBLOCK),
+		"Failed to set socket to non blocking");
+
+	fail_if(!setup_callbacks(),
+		"Failed to initialeze callbacks");
+
+	key.layer = buxton_string_pack("layer");
+	key.group = buxton_string_pack("group");
+	key.name = buxton_string_pack("name");
+	key.type = UNKNOWN;
+	fail_if(buxton_wire_get_key_type(&client, &key, NULL,
+				      NULL) != true,
+		"Failed to properly get value 1");
+
+	r = read(server, buf, 4096);
+	fail_if(r < 0, "Read from client failed 1");
+	size = buxton_deserialize_message(buf, &msg, (size_t)r, &msgid, &list);
+	fail_if(size != 4, "Failed to get valid message from buffer 1");
+	fail_if(msg != BUXTON_CONTROL_GET_KEY_TYPE,
+		"Failed to get correct control type 1");
+	fail_if(list[0].type != STRING, "Failed to set correct layer type 1");
+	fail_if(list[1].type != STRING, "Failed to set correct group type 1");
+	fail_if(list[2].type != STRING, "Failed to set correct name type 1");
+	fail_if(list[3].type != UINT32, "Failed to set correct type type 1");
+	fail_if(!streq(list[0].store.d_string.value, "layer"),
+		"Failed to set correct layer 1");
+	fail_if(!streq(list[1].store.d_string.value, "group"),
+		"Failed to set correct group 1");
+	fail_if(!streq(list[2].store.d_string.value, "name"),
+		"Failed to set correct name 1");
+	fail_if(list[3].store.d_uint32 != UNKNOWN,
+		"Failed to set correct type 1");
+
+	free(list[0].store.d_string.value);
+	free(list[1].store.d_string.value);
+	free(list[2].store.d_string.value);
+	free(list);
+
+	key.layer.value = NULL;
+	fail_if(buxton_wire_get_key_type(&client, &key, NULL,
+				      NULL) != true,
+		"Failed to properly get value 2");
+
+	r = read(server, buf, 4096);
+	fail_if(r < 0, "Read from client failed 2");
+	size = buxton_deserialize_message(buf, &msg, (size_t)r, &msgid, &list);
+	fail_if(size != 3, "Failed to get valid message from buffer 2");
+	fail_if(msg != BUXTON_CONTROL_GET_KEY_TYPE,
+		"Failed to get correct control type 2");
+	fail_if(list[0].type != STRING, "Failed to set correct group type 2");
+	fail_if(list[1].type != STRING, "Failed to set correct name type 2");
+	fail_if(list[2].type != UINT32, "Failed to set correct type type 2");
+	fail_if(!streq(list[0].store.d_string.value, "group"),
+		"Failed to set correct group 2");
+	fail_if(!streq(list[1].store.d_string.value, "name"),
+		"Failed to set correct name 2");
+	fail_if(list[2].store.d_uint32 != UNKNOWN,
+		"Failed to set correct type 2");
+
+	free(list[0].store.d_string.value);
+	free(list[1].store.d_string.value);
+	free(list);
+
+	cleanup_callbacks();
+	close(client.fd);
+	close(server);
+}
+END_TEST
+
 START_TEST(buxton_wire_get_value_check)
 {
 	_BuxtonClient client;
@@ -1177,7 +1321,9 @@ buxton_suite(void)
 	tcase_add_test(tc, buxton_direct_create_group_check);
 	tcase_add_test(tc, buxton_direct_remove_group_check);
 	tcase_add_test(tc, buxton_direct_set_value_check);
+	tcase_add_test(tc, buxton_direct_get_key_type_for_layer_check);
 	tcase_add_test(tc, buxton_direct_get_value_for_layer_check);
+	tcase_add_test(tc, buxton_direct_get_key_type_check);
 	tcase_add_test(tc, buxton_direct_get_value_check);
 	tcase_add_test(tc, buxton_memory_backend_check);
 	tcase_add_test(tc, buxton_key_check);
@@ -1194,6 +1340,7 @@ buxton_suite(void)
 	tcase_add_test(tc, buxton_wire_get_response_check);
 	tcase_add_test(tc, buxton_wire_set_value_check);
 	tcase_add_test(tc, buxton_wire_set_label_check);
+	tcase_add_test(tc, buxton_wire_get_key_type_check);
 	tcase_add_test(tc, buxton_wire_get_value_check);
 	tcase_add_test(tc, buxton_wire_unset_value_check);
 	tcase_add_test(tc, buxton_wire_create_group_check);


### PR DESCRIPTION
Get_key_type returns the type of a key's value as a uint32_t, which can
be cast to a BuxtonDataType. This commit adds buxton_get_key_type to
libbuxton, adds support functions for it in protocol, daemon, direct,
and gdbm, adds this feature to buxtonctl, and adds a new BuxtonDataType
UNKNOWN.

A demo program, bxt_hello_get_key_type, a man page, buxton_get_key_type,
and changes to other affected man pages are included.

Passing unit tests are in check_daemon and check_buxton.

Calls to buxton_get_key_type must have their key type set to UNKNOWN.
