### PR TITLE
Update repository location

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -123,5 +123,5 @@ extra unit tests within test/ - Provide these as a separate commit if
 necessary.
 
 ---
- * [1] https://github.com/sofar/buxton
+ * [1] https://github.com/intel/buxton
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 
 AC_PREREQ([2.68])
-AC_INIT([buxton],[8],[william.douglas@intel.com],[buxton],[https://github.com/sofar/buxton])
+AC_INIT([buxton],[8],[william.douglas@intel.com],[buxton],[https://github.com/intel/buxton])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror -Wno-portability silent-rules subdir-objects color-tests no-dist-gzip dist-xz])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
The original repo URL redirects to the new one, but it's more clear for
the code base to reference the current URL.